### PR TITLE
copy association operations

### DIFF
--- a/src/main/java/gov/nist/csd/pm/graph/MemGraph.java
+++ b/src/main/java/gov/nist/csd/pm/graph/MemGraph.java
@@ -338,7 +338,7 @@ public class MemGraph implements Graph {
         for (Relationship rel : rels) {
             if (rel instanceof Association) {
                 Association assoc = (Association) rel;
-                assocs.put(assoc.getTargetID(), assoc.getOperations());
+                assocs.put(assoc.getTargetID(), new HashSet<>(assoc.getOperations()));
             }
         }
         return assocs;
@@ -362,7 +362,7 @@ public class MemGraph implements Graph {
         for (Relationship rel : rels) {
             if (rel instanceof Association) {
                 Association assoc = (Association) rel;
-                assocs.put(assoc.getSourceID(), assoc.getOperations());
+                assocs.put(assoc.getSourceID(), new HashSet<>(assoc.getOperations()));
             }
         }
         return assocs;


### PR DESCRIPTION
fixes #1

Return a copy of the operations in an association instead of the actual set itself to avoid changing the graph.