### PR TITLE
Added ACL Generator Method, and Fixed Create PC method

### DIFF
--- a/src/main/java/gov/nist/csd/pm/pdp/decider/Decider.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/decider/Decider.java
@@ -68,6 +68,15 @@ public interface Decider {
      * @throws PMException if there is an error traversing the graph.
      */
     Map<Long, Set<String>> getAccessibleNodes(long userID, long processID) throws PMException;
+
+    /**
+     * Given an Object Attribute ID, returns the id of every user id (long), and what permissions(Set<String>) it has on it
+     *
+     * @param oaID
+     * @param processID
+     * @return
+     */
+    Map<Long, Set<String>> generateACL(long oaID, long processID);
 }
 
 

--- a/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
@@ -143,6 +143,8 @@ public class GraphService extends Service {
         getPAP().getGraphPAP().assign(pcUANode.getID(), pcNode.getID());
         // assign PC OA to PC
         getPAP().getGraphPAP().assign(pcOANode.getID(), pcNode.getID());
+        // assign Super U to PC UA
+        getPAP().getGraphPAP().assign(SuperGraph.getSuperU().getID(), pcUANode.getID());
         // assign super UA to PC
         getPAP().getGraphPAP().assign(SuperGraph.getSuperUA1().getID(), pcNode.getID());
         // associate Super UA and PC UA


### PR DESCRIPTION
The thing to fix in the create PC method, was just a simple assignment of the super U to the PC UA. It was discovered because when creating a new Policy Class, the super user wasn't visible anymore because it was restricted in the new PC configuration.