### PR TITLE
remove getPAP in PDP and EPP

### DIFF
--- a/src/main/java/gov/nist/csd/pm/epp/EPP.java
+++ b/src/main/java/gov/nist/csd/pm/epp/EPP.java
@@ -6,6 +6,7 @@ import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
 import gov.nist.csd.pm.pap.PAP;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.Graph;
 import gov.nist.csd.pm.pip.graph.dag.searcher.DepthFirstSearcher;
 import gov.nist.csd.pm.pip.graph.dag.searcher.Direction;
@@ -28,14 +29,14 @@ public class EPP {
     private PDP pdp;
     private FunctionEvaluator functionEvaluator;
 
-    public EPP(PDP pdp) throws PMException {
-        this.pap = pdp.getPAP();
+    public EPP(PDP pdp, PAP pap) throws PMException {
+        this.pap = pap;
         this.pdp = pdp;
         this.functionEvaluator = new FunctionEvaluator();
     }
 
-    public EPP(PDP pdp, EPPOptions eppOptions) throws PMException {
-        this.pap = pdp.getPAP();
+    public EPP(PDP pdp, PAP pap, EPPOptions eppOptions) throws PMException {
+        this.pap = pap;
         this.pdp = pdp;
         this.functionEvaluator = new FunctionEvaluator();
         if (eppOptions != null) {
@@ -44,15 +45,7 @@ public class EPP {
             }
         }
     }
-
-    public PAP getPAP() {
-        return pap;
-    }
-
-    public void setPAP(PAP pap) {
-        this.pap = pap;
-    }
-
+    
     public PDP getPDP() {
         return pdp;
     }
@@ -61,48 +54,50 @@ public class EPP {
         this.pdp = pdp;
     }
 
-    public void processEvent(EventContext eventCtx, String user, String process) throws PMException {
+    public void processEvent(EventContext eventCtx) throws PMException {
         List<Obligation> obligations = pap.getObligationsPAP().getAll();
         for(Obligation obligation : obligations) {
             if (!obligation.isEnabled()) {
                 continue;
             }
 
+            UserContext definingUser = new UserContext(obligation.getUser());
+
             List<Rule> rules = obligation.getRules();
             for(Rule rule : rules) {
-                if(!eventMatches(user, process, eventCtx.getEvent(), eventCtx.getTarget(), rule.getEventPattern())) {
+                if(!eventMatches(eventCtx.getUserCtx(), eventCtx.getEvent(), eventCtx.getTarget(), rule.getEventPattern())) {
                     continue;
                 }
 
                 // check the response condition
                 ResponsePattern responsePattern = rule.getResponsePattern();
-                if(!checkCondition(responsePattern.getCondition(), eventCtx, user, process, pdp)) {
+                if(!checkCondition(definingUser, responsePattern.getCondition(), eventCtx, pdp)) {
                     continue;
-                } else if(!checkNegatedCondition(responsePattern.getNegatedCondition(), eventCtx, user, process, pdp)) {
+                } else if(!checkNegatedCondition(definingUser, responsePattern.getNegatedCondition(), eventCtx, pdp)) {
                     continue;
                 }
 
                 for(Action action : rule.getResponsePattern().getActions()) {
-                    if(!checkCondition(action.getCondition(), eventCtx, user, process, pdp)) {
+                    if(!checkCondition(definingUser, action.getCondition(), eventCtx, pdp)) {
                         continue;
-                    } else if(!checkNegatedCondition(action.getNegatedCondition(), eventCtx, user, process, pdp)) {
+                    } else if(!checkNegatedCondition(definingUser, action.getNegatedCondition(), eventCtx, pdp)) {
                         continue;
                     }
 
-                    applyAction(obligation.getLabel(), eventCtx, user, process, action);
+                    applyAction(definingUser, obligation.getLabel(), eventCtx, action);
                 }
             }
         }
     }
 
-    private boolean checkCondition(Condition condition, EventContext eventCtx, String user, String process, PDP pdp) throws PMException {
+    private boolean checkCondition(UserContext definingUser, Condition condition, EventContext eventCtx, PDP pdp) throws PMException {
         if(condition == null) {
             return true;
         }
 
         List<Function> functions = condition.getCondition();
         for(Function f : functions) {
-            boolean result = functionEvaluator.evalBool(eventCtx, user, process, pdp, f);
+            boolean result = functionEvaluator.evalBool(definingUser, eventCtx, pdp, f);
             if(!result) {
                 return false;
             }
@@ -114,14 +109,14 @@ public class EPP {
     /**
      * Return true if the condition is satisfied. A condition is satisfied if all the functions evaluate to false.
      */
-    private boolean checkNegatedCondition(NegatedCondition condition, EventContext eventCtx, String user, String process, PDP pdp) throws PMException {
+    private boolean checkNegatedCondition(UserContext definingUser, NegatedCondition condition, EventContext eventCtx, PDP pdp) throws PMException {
         if(condition == null) {
             return true;
         }
 
         List<Function> functions = condition.getCondition();
         for(Function f : functions) {
-            boolean result = functionEvaluator.evalBool(eventCtx, user, process, pdp, f);
+            boolean result = functionEvaluator.evalBool(definingUser, eventCtx, pdp, f);
             if(result) {
                 return false;
             }
@@ -130,7 +125,7 @@ public class EPP {
         return true;
     }
 
-    private boolean eventMatches(String user, String process, String event, Node target, EventPattern match) throws PMException {
+    private boolean eventMatches(UserContext userCtx, String event, Node target, EventPattern match) throws PMException {
         if(match.getOperations() != null &&
                 !match.getOperations().contains(event)) {
             return false;
@@ -140,8 +135,8 @@ public class EPP {
         PolicyClass matchPolicyClass = match.getPolicyClass();
         Target matchTarget = match.getTarget();
 
-        return subjectMatches(user, process, matchSubject) &&
-                pcMatches(user, matchPolicyClass) &&
+        return subjectMatches(userCtx.getUser(), userCtx.getProcess(), matchSubject) &&
+                pcMatches(userCtx.getUser(), userCtx.getProcess(), matchPolicyClass) &&
                 targetMatches(target, matchTarget);
     }
 
@@ -176,12 +171,12 @@ public class EPP {
             return true;
         }
 
-        DepthFirstSearcher dfs = new DepthFirstSearcher(pdp.getPAP().getGraphPAP());
+        DepthFirstSearcher dfs = new DepthFirstSearcher(pap.getGraphPAP());
 
         // check each user in the anyUser list
         // there can be users and user attributes
         for (String u : anyUser) {
-            Node anyUserNode = pdp.getPAP().getGraphPAP().getNode(u);
+            Node anyUserNode = pap.getGraphPAP().getNode(u);
 
             // if the node in anyUser == the user than return true
             if (anyUserNode.getName().equals(userNode.getName())) {
@@ -209,7 +204,7 @@ public class EPP {
         return false;
     }
 
-    private boolean pcMatches(String user, PolicyClass matchPolicyClass) {
+    private boolean pcMatches(String user, String process, PolicyClass matchPolicyClass) {
         // not yet implemented
         return true;
     }
@@ -291,44 +286,44 @@ public class EPP {
         return nodes;
     }
 
-    private void applyAction(String label, EventContext eventCtx, String user, String process, Action action) throws PMException {
+    private void applyAction(UserContext definingUser, String label, EventContext eventCtx, Action action) throws PMException {
         if (action == null) {
             return;
         }
 
         if(action instanceof AssignAction) {
-            applyAssignAction(eventCtx, user, process, (AssignAction) action);
+            applyAssignAction(definingUser, eventCtx, (AssignAction) action);
         } else if(action instanceof CreateAction) {
-            applyCreateAction(label, eventCtx, user, process, (CreateAction) action);
+            applyCreateAction(definingUser, label, eventCtx, (CreateAction) action);
         } else if(action instanceof DeleteAction) {
-            applyDeleteAction(eventCtx, user, process, (DeleteAction) action);
+            applyDeleteAction(definingUser, eventCtx, (DeleteAction) action);
         } else if(action instanceof DenyAction) {
-            applyDenyAction(eventCtx, user, process, (DenyAction) action);
+            applyDenyAction(definingUser, eventCtx, (DenyAction) action);
         } else if(action instanceof GrantAction) {
-            applyGrantAction(eventCtx, user, process, (GrantAction) action);
+            applyGrantAction(definingUser, eventCtx, (GrantAction) action);
         } else if(action instanceof FunctionAction) {
-            functionEvaluator.evalNode(eventCtx, user, process, pdp, ((FunctionAction) action).getFunction());
+            functionEvaluator.evalNode(definingUser, eventCtx, pdp, ((FunctionAction) action).getFunction());
         }
     }
 
-    private void applyGrantAction(EventContext eventCtx, String user, String process, GrantAction action) throws PMException {
+    private void applyGrantAction(UserContext definingUser, EventContext eventCtx, GrantAction action) throws PMException {
         EvrNode subject = action.getSubject();
         List<String> operations = action.getOperations();
         EvrNode target = action.getTarget();
 
-        Node subjectNode = toNode(eventCtx, user, process, subject);
-        Node targetNode = toNode(eventCtx, user, process, target);
+        Node subjectNode = toNode(definingUser, eventCtx, subject);
+        Node targetNode = toNode(definingUser, eventCtx, target);
 
         pap.getGraphPAP().associate(subjectNode.getName(), targetNode.getName(), new OperationSet(operations));
     }
 
-    private void applyDenyAction(EventContext eventCtx, String user, String process, DenyAction action) throws PMException {
+    private void applyDenyAction(UserContext definingUser, EventContext eventCtx, DenyAction action) throws PMException {
         EvrNode subject = action.getSubject();
         List<String> operations = action.getOperations();
         DenyAction.Target target = action.getTarget();
 
-        String denySubject = toDenySubject(eventCtx, user, process, subject);
-        Map<String, Boolean> denyNodes = toDenyNodes(eventCtx, user, process, target);
+        String denySubject = toDenySubject(definingUser, eventCtx, subject);
+        Map<String, Boolean> denyNodes = toDenyNodes(definingUser, eventCtx, target);
 
         Prohibition.Builder builder = new Prohibition.Builder(action.getLabel(), denySubject, new OperationSet(operations))
                 .setIntersection(target.isIntersection());
@@ -344,13 +339,13 @@ public class EPP {
         boolean complement = target.isComplement();
     }
 
-    private Map<String, Boolean> toDenyNodes(EventContext eventCtx, String user, String process, DenyAction.Target target) throws PMException {
+    private Map<String, Boolean> toDenyNodes(UserContext definingUser, EventContext eventCtx, DenyAction.Target target) throws PMException {
         Map<String, Boolean> nodes = new HashMap<>();
         List<DenyAction.Target.Container> containers = target.getContainers();
         for(DenyAction.Target.Container container : containers) {
             if(container.getFunction() != null) {
                 Function function = container.getFunction();
-                Object result = functionEvaluator.evalObject(eventCtx, user, process, pdp, function);
+                Object result = functionEvaluator.evalObject(definingUser, eventCtx, pdp, function);
 
                 if(!(result instanceof ContainerCondition)) {
                     throw new PMException("expected function to return a ContainerCondition but got " + result.getClass().getName());
@@ -370,12 +365,12 @@ public class EPP {
         return nodes;
     }
 
-    private String toDenySubject(EventContext eventCtx, String user, String process, EvrNode subject) throws PMException {
+    private String toDenySubject(UserContext definingUser, EventContext eventCtx, EvrNode subject) throws PMException {
         String denySubject;
 
         if(subject.getFunction() != null) {
             Function function = subject.getFunction();
-            denySubject = functionEvaluator.evalString(eventCtx, user, process, pdp, function);
+            denySubject = functionEvaluator.evalString(definingUser, eventCtx, pdp, function);
         } else if(subject.getProcess() != null) {
             denySubject = subject.getProcess().getValue();
         } else {
@@ -389,44 +384,44 @@ public class EPP {
         return denySubject;
     }
 
-    private void applyDeleteAction(EventContext eventCtx, String user, String process, DeleteAction action) throws PMException {
+    private void applyDeleteAction(UserContext definingUser, EventContext eventCtx, DeleteAction action) throws PMException {
         List<EvrNode> nodes = action.getNodes();
         if (nodes != null) {
             for (EvrNode evrNode : nodes) {
-                Node node = toNode(eventCtx, user, process, evrNode);
-                pdp.getPAP().getGraphPAP().deleteNode(node.getName());
+                Node node = toNode(definingUser, eventCtx, evrNode);
+                pap.getGraphPAP().deleteNode(node.getName());
             }
         }
 
         AssignAction assignAction = action.getAssignments();
         if (assignAction != null) {
             for (AssignAction.Assignment assignment : assignAction.getAssignments()) {
-                Node what = toNode(eventCtx, user, process, assignment.getWhat());
-                Node where = toNode(eventCtx, user, process, assignment.getWhere());
-                pdp.getPAP().getGraphPAP().deassign(what.getName(), where.getName());
+                Node what = toNode(definingUser, eventCtx, assignment.getWhat());
+                Node where = toNode(definingUser, eventCtx, assignment.getWhere());
+                pap.getGraphPAP().deassign(what.getName(), where.getName());
             }
         }
 
         List<GrantAction> associations = action.getAssociations();
         if (associations != null){
             for (GrantAction grantAction : associations) {
-                Node subject = toNode(eventCtx, user, process, grantAction.getSubject());
-                Node target = toNode(eventCtx, user, process, grantAction.getTarget());
-                pdp.getPAP().getGraphPAP().dissociate(subject.getName(), target.getName());
+                Node subject = toNode(definingUser, eventCtx, grantAction.getSubject());
+                Node target = toNode(definingUser, eventCtx, grantAction.getTarget());
+                pap.getGraphPAP().dissociate(subject.getName(), target.getName());
             }
         }
 
         List<String> prohibitions = action.getProhibitions();
         if (prohibitions != null) {
             for (String label : prohibitions) {
-                pdp.getPAP().getProhibitionsPAP().delete(label);
+                pap.getProhibitionsPAP().delete(label);
             }
         }
 
         List<String> rules = action.getRules();
         if (rules != null) {
             for (String label : rules) {
-                List<Obligation> obligations = pdp.getPAP().getObligationsPAP().getAll();
+                List<Obligation> obligations = pap.getObligationsPAP().getAll();
                 for (Obligation obligation : obligations) {
                     List<Rule> oblRules = obligation.getRules();
                     for (Rule rule : oblRules) {
@@ -439,10 +434,10 @@ public class EPP {
         }
     }
 
-    private Node toNode(EventContext eventCtx, String user, String process, EvrNode evrNode) throws PMException {
+    private Node toNode(UserContext definingUser, EventContext eventCtx, EvrNode evrNode) throws PMException {
         Node node;
         if(evrNode.getFunction() != null) {
-            node = functionEvaluator.evalNode(eventCtx, user, process, pdp, evrNode.getFunction());
+            node = functionEvaluator.evalNode(definingUser, eventCtx, pdp, evrNode.getFunction());
         } else {
             if (evrNode.getName() != null && !evrNode.getName().isEmpty()) {
                 node = pap.getGraphPAP().getNode(evrNode.getName());
@@ -453,7 +448,7 @@ public class EPP {
         return node;
     }
 
-    private void applyCreateAction(String label, EventContext eventCtx, String user, String process, CreateAction action) throws PMException {
+    private void applyCreateAction(UserContext definingUser, String label, EventContext eventCtx, CreateAction action) throws PMException {
         List<Rule> rules = action.getRules();
         if (rules != null) {
             for (Rule rule : rules) {
@@ -466,7 +461,7 @@ public class EPP {
             for (CreateAction.CreateNode createNode : createNodesList) {
                 EvrNode what = createNode.getWhat();
                 EvrNode where = createNode.getWhere();
-                Node whereNode = toNode(eventCtx, user, process, where);
+                Node whereNode = toNode(definingUser, eventCtx, where);
                 pap.getGraphPAP().createNode(what.getName(), NodeType.toNodeType(what.getType()), what.getProperties(), whereNode.getName());
             }
         }
@@ -480,15 +475,15 @@ public class EPP {
         obligation.setRules(rules);
     }
 
-    private void applyAssignAction(EventContext eventCtx, String user, String process, AssignAction action) throws PMException {
+    private void applyAssignAction(UserContext definingUser, EventContext eventCtx, AssignAction action) throws PMException {
         List<AssignAction.Assignment> assignments = action.getAssignments();
         if (assignments != null) {
             for (AssignAction.Assignment assignment : assignments) {
                 EvrNode what = assignment.getWhat();
                 EvrNode where = assignment.getWhere();
 
-                Node whatNode = toNode(eventCtx, user, process, what);
-                Node whereNode = toNode(eventCtx, user, process, where);
+                Node whatNode = toNode(definingUser, eventCtx, what);
+                Node whereNode = toNode(definingUser, eventCtx, where);
 
                 pap.getGraphPAP().assign(whatNode.getName(), whereNode.getName());
             }

--- a/src/main/java/gov/nist/csd/pm/epp/FunctionEvaluator.java
+++ b/src/main/java/gov/nist/csd/pm/epp/FunctionEvaluator.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.events.*;
 import gov.nist.csd.pm.epp.functions.*;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
@@ -42,46 +43,46 @@ public class FunctionEvaluator {
         return funExecs.get(name);
     }
 
-    public boolean evalBool(EventContext eventCtx, String user, String process, PDP pdp, Function function) throws PMException {
+    public boolean evalBool(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function) throws PMException {
         String functionName = function.getName();
         FunctionExecutor functionExecutor = getFunctionExecutor(functionName);
 
-        return (boolean)functionExecutor.exec(eventCtx, user, process, pdp, function, this);
+        return (boolean)functionExecutor.exec(obligationUser, eventCtx, pdp, function, this);
     }
 
-    public List evalNodeList(EventContext eventCtx, String user, String process, PDP pdp, Function function) throws PMException {
+    public List evalNodeList(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function) throws PMException {
         String functionName = function.getName();
         FunctionExecutor functionExecutor = getFunctionExecutor(functionName);
-        return (List) functionExecutor.exec(eventCtx, user, process, pdp, function, this);
+        return (List) functionExecutor.exec(obligationUser, eventCtx, pdp, function, this);
     }
 
-    public Node evalNode(EventContext eventCtx, String user, String process, PDP pdp, Function function) throws PMException {
+    public Node evalNode(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function) throws PMException {
         String functionName = function.getName();
         FunctionExecutor functionExecutor = getFunctionExecutor(functionName);
-        return (Node)functionExecutor.exec(eventCtx, user, process, pdp, function, this);
+        return (Node)functionExecutor.exec(obligationUser, eventCtx, pdp, function, this);
     }
 
-    public String evalString(EventContext eventCtx, String user, String process, PDP pdp, Function function) throws PMException {
+    public String evalString(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function) throws PMException {
         String functionName = function.getName();
         FunctionExecutor functionExecutor = getFunctionExecutor(functionName);
-        return (String)functionExecutor.exec(eventCtx, user, process, pdp, function, this);
+        return (String)functionExecutor.exec(obligationUser, eventCtx, pdp, function, this);
     }
 
-    public String evalLong(EventContext eventCtx, String user, String process, PDP pdp, Function function) throws PMException {
+    public String evalLong(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function) throws PMException {
         String functionName = function.getName();
         FunctionExecutor functionExecutor = getFunctionExecutor(functionName);
-        return (String)functionExecutor.exec(eventCtx, user, process, pdp, function, this);
+        return (String)functionExecutor.exec(obligationUser, eventCtx, pdp, function, this);
     }
 
-    public Map evalMap(EventContext eventCtx, String user, String process, PDP pdp, Function function) throws PMException {
+    public Map evalMap(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function) throws PMException {
         String functionName = function.getName();
         FunctionExecutor functionExecutor = getFunctionExecutor(functionName);
-        return (Map)functionExecutor.exec(eventCtx, user, process, pdp, function, this);
+        return (Map)functionExecutor.exec(obligationUser, eventCtx, pdp, function, this);
     }
 
-    public Object evalObject(EventContext eventCtx, String user, String process, PDP pdp, Function function) throws PMException {
+    public Object evalObject(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function) throws PMException {
         String functionName = function.getName();
         FunctionExecutor functionExecutor = getFunctionExecutor(functionName);
-        return functionExecutor.exec(eventCtx, user, process, pdp, function, this);
+        return functionExecutor.exec(obligationUser, eventCtx, pdp, function, this);
     }
 }

--- a/src/main/java/gov/nist/csd/pm/epp/events/AssignEvent.java
+++ b/src/main/java/gov/nist/csd/pm/epp/events/AssignEvent.java
@@ -1,13 +1,14 @@
 package gov.nist.csd.pm.epp.events;
 
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 
 public class AssignEvent extends EventContext {
 
     private Node parentNode;
 
-    public AssignEvent(Node target, Node parentNode) {
-        super(ASSIGN_EVENT, target);
+    public AssignEvent(UserContext userCtx, Node target, Node parentNode) {
+        super(userCtx, ASSIGN_EVENT, target);
         this.parentNode = parentNode;
     }
 

--- a/src/main/java/gov/nist/csd/pm/epp/events/AssignToEvent.java
+++ b/src/main/java/gov/nist/csd/pm/epp/events/AssignToEvent.java
@@ -1,13 +1,14 @@
 package gov.nist.csd.pm.epp.events;
 
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 
 public class AssignToEvent extends EventContext {
 
     private Node childNode;
 
-    public AssignToEvent(Node target, Node childNode) {
-        super(ASSIGN_TO_EVENT, target);
+    public AssignToEvent(UserContext userCtx, Node target, Node childNode) {
+        super(userCtx, ASSIGN_TO_EVENT, target);
         this.childNode = childNode;
     }
 

--- a/src/main/java/gov/nist/csd/pm/epp/events/DeassignEvent.java
+++ b/src/main/java/gov/nist/csd/pm/epp/events/DeassignEvent.java
@@ -1,13 +1,14 @@
 package gov.nist.csd.pm.epp.events;
 
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 
 public class DeassignEvent extends EventContext {
 
     private Node parentNode;
 
-    public DeassignEvent(Node target, Node parentNode) {
-        super(DEASSIGN_EVENT, target);
+    public DeassignEvent(UserContext userCtx, Node target, Node parentNode) {
+        super(userCtx, DEASSIGN_EVENT, target);
         this.parentNode = parentNode;
     }
 

--- a/src/main/java/gov/nist/csd/pm/epp/events/DeassignFromEvent.java
+++ b/src/main/java/gov/nist/csd/pm/epp/events/DeassignFromEvent.java
@@ -1,13 +1,14 @@
 package gov.nist.csd.pm.epp.events;
 
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 
 public class DeassignFromEvent extends EventContext {
 
     private Node childNode;
 
-    public DeassignFromEvent(Node target, Node childNode) {
-        super(DEASSIGN_FROM_EVENT, target);
+    public DeassignFromEvent(UserContext userCtx, Node target, Node childNode) {
+        super(userCtx, DEASSIGN_FROM_EVENT, target);
         this.childNode = childNode;
     }
 

--- a/src/main/java/gov/nist/csd/pm/epp/events/EventContext.java
+++ b/src/main/java/gov/nist/csd/pm/epp/events/EventContext.java
@@ -1,5 +1,6 @@
 package gov.nist.csd.pm.epp.events;
 
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 
 public class EventContext {
@@ -10,12 +11,18 @@ public class EventContext {
     public static final String DEASSIGN_EVENT = "deassign";
     public static final String ACCESS_DENIED_EVENT = "deassign";
 
+    private UserContext userCtx;
     private String event;
     private Node   target;
 
-    public EventContext(String event, Node target) {
+    public EventContext(UserContext userCtx, String event, Node target) {
+        this.userCtx = userCtx;
         this.event = event;
         this.target = target;
+    }
+
+    public UserContext getUserCtx() {
+        return userCtx;
     }
 
     public String getEvent() {

--- a/src/main/java/gov/nist/csd/pm/epp/events/ObjectAccessEvent.java
+++ b/src/main/java/gov/nist/csd/pm/epp/events/ObjectAccessEvent.java
@@ -1,9 +1,10 @@
 package gov.nist.csd.pm.epp.events;
 
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 
 public class ObjectAccessEvent extends EventContext {
-    public ObjectAccessEvent(String event, Node target) {
-        super(event, target);
+    public ObjectAccessEvent(UserContext userCtx, String event, Node target) {
+        super(userCtx, event, target);
     }
 }

--- a/src/main/java/gov/nist/csd/pm/epp/functions/ChildOfAssignExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/ChildOfAssignExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.*;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.evr.EVRException;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -20,7 +21,7 @@ public class ChildOfAssignExecutor implements FunctionExecutor {
     }
 
     @Override
-    public Node exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+    public Node exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
         Node child;
         if(eventCtx instanceof AssignToEvent) {
             child = ((AssignToEvent) eventCtx).getChildNode();

--- a/src/main/java/gov/nist/csd/pm/epp/functions/CreateNodeExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/CreateNodeExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.Graph;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.graph.model.nodes.NodeType;
@@ -28,44 +29,35 @@ public class CreateNodeExecutor implements FunctionExecutor {
     }
 
     @Override
-    public Node exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+    public Node exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
         List<Arg> args = function.getArgs();
 
         // first arg is the name, can be function that returns a string
         Arg parentNameArg = args.get(0);
         String parentName = parentNameArg.getValue();
         if(parentNameArg.getFunction() != null) {
-            parentName = functionEvaluator.evalString(eventCtx, user, process, pdp, parentNameArg.getFunction());
+            parentName = functionEvaluator.evalString(obligationUser, eventCtx, pdp, parentNameArg.getFunction());
         }
 
         // second arg is the type, can be function
         Arg parentTypeArg = args.get(1);
         String parentType = parentTypeArg.getValue();
         if(parentTypeArg.getFunction() != null) {
-            parentType = functionEvaluator.evalString(eventCtx, user, process, pdp, parentTypeArg.getFunction());
+            parentType = functionEvaluator.evalString(obligationUser, eventCtx, pdp, parentTypeArg.getFunction());
         }
-
-        // third arg is the properties which is a map that has to come from a function
-        /*Map<String, String> parentProps = new HashMap<>();
-        if(args.size() > 2) {
-            Arg propsArg = args.get(2);
-            if (propsArg.getFunction() != null) {
-                parentProps = (Map) functionEvaluator.evalMap(eventCtx, user, process, pdp, propsArg.getFunction());
-            }
-        }*/
 
         // fourth arg is the name, can be function
         Arg nameArg = args.get(2);
         String name = nameArg.getValue();
         if(nameArg.getFunction() != null) {
-            name = functionEvaluator.evalString(eventCtx, user, process, pdp, nameArg.getFunction());
+            name = functionEvaluator.evalString(obligationUser, eventCtx, pdp, nameArg.getFunction());
         }
 
         // fifth arg is the type, can be function
         Arg typeArg = args.get(3);
         String type = typeArg.getValue();
         if(typeArg.getFunction() != null) {
-            type = functionEvaluator.evalString(eventCtx, user, process, pdp, typeArg.getFunction());
+            type = functionEvaluator.evalString(obligationUser, eventCtx, pdp, typeArg.getFunction());
         }
 
         // sixth arg is the properties which is a map that has to come from a function
@@ -73,11 +65,11 @@ public class CreateNodeExecutor implements FunctionExecutor {
         if(args.size() > 4) {
             Arg propsArg = args.get(4);
             if (propsArg.getFunction() != null) {
-                props = (Map) functionEvaluator.evalMap(eventCtx, user, process, pdp, propsArg.getFunction());
+                props = (Map) functionEvaluator.evalMap(obligationUser, eventCtx, pdp, propsArg.getFunction());
             }
         }
 
-        Graph graph = pdp.getPAP().getGraphPAP();
+        Graph graph = pdp.getGraphService(obligationUser);
 
         Node parentNode;
         if (parentName != null) {

--- a/src/main/java/gov/nist/csd/pm/epp/functions/CurrentProcessExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/CurrentProcessExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
 
@@ -18,12 +19,8 @@ public class CurrentProcessExecutor implements FunctionExecutor {
         return 0;
     }
 
-    /**
-     * The current process is only relevant to prohibitions.  So the function returns a Prohibition.Subject with the
-     * current processID and type PROCESS.
-     */
     @Override
-    public String exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
-        return process;
+    public String exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) {
+        return eventCtx.getUserCtx().getProcess();
     }
 }

--- a/src/main/java/gov/nist/csd/pm/epp/functions/CurrentTargetExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/CurrentTargetExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 
@@ -19,7 +20,7 @@ public class CurrentTargetExecutor implements FunctionExecutor {
     }
 
     @Override
-    public Node exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+    public Node exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
         return eventCtx.getTarget();
     }
 }

--- a/src/main/java/gov/nist/csd/pm/epp/functions/CurrentUserExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/CurrentUserExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 
@@ -18,11 +19,10 @@ public class CurrentUserExecutor implements FunctionExecutor {
         return 0;
     }
 
-    /**
-     * @return the Node with the given userID
-     */
     @Override
-    public Node exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
-        return pdp.getPAP().getGraphPAP().getNode(user);
+    public Node exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+        return pdp
+                .getGraphService(obligationUser)
+                .getNode(eventCtx.getUserCtx().getUser());
     }
 }

--- a/src/main/java/gov/nist/csd/pm/epp/functions/FunctionExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/FunctionExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 
 public interface FunctionExecutor {
@@ -22,14 +23,14 @@ public interface FunctionExecutor {
 
     /**
      * Execute the function.
+     * @param obligationUser is the user that defined the obligation being executed.  It is this user that needs permissions
+     *                       to carry out the actions in the function.
      * @param eventCtx the event that is being processed
-     * @param user the name of the user that triggered the event
-     * @param process the process that triggered the event
      * @param pdp the PDP to access the underlying policy data
      * @param function the function information
      * @param functionEvaluator a FunctionEvaluator to evaluate a nested functions
      * @return the object that the function is expected to return
      * @throws PMException if there is any error executing the function
      */
-    Object exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException;
+    Object exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException;
 }

--- a/src/main/java/gov/nist/csd/pm/epp/functions/GetChildrenExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/GetChildrenExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -24,10 +25,10 @@ public class GetChildrenExecutor implements FunctionExecutor {
     }
 
     @Override
-    public List<String> exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+    public List<String> exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
         FunctionExecutor getNodeExecutor = functionEvaluator.getFunctionExecutor("get_node");
-        Node node = (Node)getNodeExecutor.exec(eventCtx, user, process, pdp, function, functionEvaluator);
-        Set<String> children = pdp.getPAP().getGraphPAP().getChildren(node.getName());
+        Node node = (Node)getNodeExecutor.exec(obligationUser, eventCtx, pdp, function, functionEvaluator);
+        Set<String> children = pdp.getGraphService(obligationUser).getChildren(node.getName());
         return new ArrayList<>(children);
     }
 }

--- a/src/main/java/gov/nist/csd/pm/epp/functions/GetNodeNameExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/GetNodeNameExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -21,12 +22,8 @@ public class GetNodeNameExecutor implements FunctionExecutor {
         return 1;
     }
 
-    /**
-     * A function that returns a Node is the only expected parameter in the Function parameter.
-     * @return the name of the node returned from this function.
-     */
     @Override
-    public String exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+    public String exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
         List<Arg> args = function.getArgs();
         if (args.size() != numParams()) {
             throw new PMException(getFunctionName() + " expected " + numParams() + " arg but got " + args.size());
@@ -38,7 +35,7 @@ public class GetNodeNameExecutor implements FunctionExecutor {
             throw new PMException(getFunctionName() + " expected the first argument to be a function but it was null");
         }
 
-        Node node = functionEvaluator.evalNode(eventCtx, user, process, pdp, argFunction);
+        Node node = functionEvaluator.evalNode(obligationUser, eventCtx, pdp, argFunction);
         return node.getName();
     }
 }

--- a/src/main/java/gov/nist/csd/pm/epp/functions/IsNodeContainedInExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/IsNodeContainedInExecutor.java
@@ -4,6 +4,8 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
+import gov.nist.csd.pm.pip.graph.Graph;
 import gov.nist.csd.pm.pip.graph.dag.searcher.DepthFirstSearcher;
 import gov.nist.csd.pm.pip.graph.dag.searcher.Direction;
 import gov.nist.csd.pm.pip.graph.dag.visitor.Visitor;
@@ -27,7 +29,7 @@ public class IsNodeContainedInExecutor implements FunctionExecutor {
     }
 
     @Override
-    public Boolean exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+    public Boolean exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
         List< Arg > args = function.getArgs();
         if (args.size() != numParams()) {
             throw new PMException(getFunctionName() + " expected " + numParams() + " parameters but got " + args.size());
@@ -39,7 +41,7 @@ public class IsNodeContainedInExecutor implements FunctionExecutor {
             throw new PMException(getFunctionName() + " expects two functions as parameters");
         }
 
-        Node childNode = functionEvaluator.evalNode(eventCtx, user, process, pdp, f);
+        Node childNode = functionEvaluator.evalNode(obligationUser, eventCtx, pdp, f);
         if(childNode == null) {
             return false;
         }
@@ -50,12 +52,13 @@ public class IsNodeContainedInExecutor implements FunctionExecutor {
             throw new PMException(getFunctionName() + " expects two functions as parameters");
         }
 
-        Node parentNode = functionEvaluator.evalNode(eventCtx, user, process, pdp, f);
+        Node parentNode = functionEvaluator.evalNode(obligationUser, eventCtx, pdp, f);
         if(parentNode == null) {
             return false;
         }
 
-        DepthFirstSearcher dfs = new DepthFirstSearcher(pdp.getPAP().getGraphPAP());
+        Graph graph = pdp.getGraphService(obligationUser);
+        DepthFirstSearcher dfs = new DepthFirstSearcher(graph);
         Set<String> nodes = new HashSet<>();
         Visitor visitor = node -> {
             if (node.getName().equals(parentNode.getName())) {

--- a/src/main/java/gov/nist/csd/pm/epp/functions/ParentOfAssignExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/ParentOfAssignExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.*;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.evr.EVRException;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -20,7 +21,7 @@ public class ParentOfAssignExecutor implements FunctionExecutor {
     }
 
     @Override
-    public Node exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+    public Node exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
         Node parent;
         if(eventCtx instanceof AssignToEvent) {
             parent = eventCtx.getTarget();

--- a/src/main/java/gov/nist/csd/pm/epp/functions/ToPropertiesExecutor.java
+++ b/src/main/java/gov/nist/csd/pm/epp/functions/ToPropertiesExecutor.java
@@ -4,6 +4,7 @@ import gov.nist.csd.pm.epp.FunctionEvaluator;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 
@@ -21,13 +22,8 @@ public class ToPropertiesExecutor implements FunctionExecutor {
         return 0;
     }
 
-    /**
-     * The args should all be strings with the format: "key=value"
-     * This function takes those strings and returns a Map<String,String> to be used
-     * as a node's properties
-     */
     @Override
-    public Map<String, String> exec(EventContext eventCtx, String user, String process, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
+    public Map<String, String> exec(UserContext obligationUser, EventContext eventCtx, PDP pdp, Function function, FunctionEvaluator functionEvaluator) throws PMException {
         Map<String, String> props = new HashMap<>();
         for(Arg arg : function.getArgs()) {
             String value = arg.getValue();

--- a/src/main/java/gov/nist/csd/pm/pdp/PDP.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/PDP.java
@@ -32,7 +32,7 @@ public class PDP {
     public PDP(PAP pap, EPPOptions eppOptions) throws PMException {
         this.pap = pap;
 
-        this.epp = new EPP(this, eppOptions);
+        this.epp = new EPP(this, pap, eppOptions);
 
         // initialize services
         this.graphService = new GraphService(this.pap, this.epp);
@@ -46,10 +46,6 @@ public class PDP {
 
     public EPP getEPP() {
         return epp;
-    }
-
-    public PAP getPAP() {
-        return pap;
     }
 
     public Graph getGraphService(UserContext userCtx) {

--- a/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
@@ -155,11 +155,11 @@ public class GraphService extends Service implements Graph {
         Node node = getGraphPAP().createNode(name, type, properties, initialParent, additionalParents);
 
         // process event for initial parent
-        getEPP().processEvent(new AssignToEvent(parentNode, node), userCtx.getUser(), userCtx.getProcess());
+        getEPP().processEvent(new AssignToEvent(userCtx, parentNode, node));
         // process event for any additional parents
         for (String parent : additionalParents) {
             parentNode = graph.getNode(parent);
-            getEPP().processEvent(new AssignToEvent(parentNode, node), userCtx.getUser(), userCtx.getProcess());
+            getEPP().processEvent(new AssignToEvent(userCtx, parentNode, node));
         }
 
         return node;
@@ -221,8 +221,8 @@ public class GraphService extends Service implements Graph {
 
             Node parentNode = getGraphPAP().getNode(parent);
 
-            getEPP().processEvent(new DeassignEvent(node, parentNode), userCtx.getUser(), userCtx.getProcess());
-            getEPP().processEvent(new DeassignFromEvent(parentNode, node), userCtx.getUser(), userCtx.getProcess());
+            getEPP().processEvent(new DeassignEvent(userCtx, node, parentNode));
+            getEPP().processEvent(new DeassignFromEvent(userCtx, parentNode, node));
         }
 
         // if it's a PC, delete the rep
@@ -415,8 +415,8 @@ public class GraphService extends Service implements Graph {
         // assign in the PAP
         getGraphPAP().assign(child, parent);
 
-        getEPP().processEvent(new AssignEvent(childNode, parentNode), userCtx.getUser(), userCtx.getProcess());
-        getEPP().processEvent(new AssignToEvent(parentNode, childNode), userCtx.getUser(), userCtx.getProcess());
+        getEPP().processEvent(new AssignEvent(userCtx, childNode, parentNode));
+        getEPP().processEvent(new AssignToEvent(userCtx, parentNode, childNode));
     }
 
     /**
@@ -461,8 +461,8 @@ public class GraphService extends Service implements Graph {
         Node parentNode = getNode(parent);
         Node childNode = getNode(child);
 
-        getEPP().processEvent(new DeassignEvent(childNode, parentNode), userCtx.getUser(), userCtx.getProcess());
-        getEPP().processEvent(new DeassignFromEvent(parentNode, childNode), userCtx.getUser(), userCtx.getProcess());
+        getEPP().processEvent(new DeassignEvent(userCtx, childNode, parentNode));
+        getEPP().processEvent(new DeassignFromEvent(userCtx, parentNode, childNode));
     }
 
     @Override

--- a/src/main/java/gov/nist/csd/pm/pip/obligations/evr/EVRParser.java
+++ b/src/main/java/gov/nist/csd/pm/pip/obligations/evr/EVRParser.java
@@ -27,26 +27,26 @@ public class EVRParser {
         return type.cast(o);
     }
 
-    public static Obligation parse(String yml) throws EVRException {
+    public static Obligation parse(String user, String yml) throws EVRException {
         Yaml yaml = new Yaml();
         Map<Object, Object> map = yaml.load(yml);
 
-        return parse(map);
+        return parse(user, map);
     }
 
     /**
      * label: string required
      * rules: array
      */
-    public static Obligation parse(InputStream is) throws EVRException {
+    public static Obligation parse(String user, InputStream is) throws EVRException {
         Yaml yaml = new Yaml();
         Map<Object, Object> map = yaml.load(is);
 
-        return parse(map);
+        return parse(user, map);
     }
 
-    public static Obligation parse(Map<Object, Object> map) throws EVRException {
-        Obligation obligation = new Obligation();
+    private static Obligation parse(String user, Map<Object, Object> map) throws EVRException {
+        Obligation obligation = new Obligation(user);
 
         String label = getObject(map.get("label"), String.class);
         if (label == null) {

--- a/src/main/java/gov/nist/csd/pm/pip/obligations/model/Obligation.java
+++ b/src/main/java/gov/nist/csd/pm/pip/obligations/model/Obligation.java
@@ -4,13 +4,23 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Obligation {
+    private String user;
     private boolean enabled;
     private String     label;
     private List<Rule> rules;
     private String source;
 
-    public Obligation() {
+    public Obligation(String user) {
+        this.user = user;
         this.rules = new ArrayList<>();
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
     }
 
     public boolean isEnabled() {

--- a/src/test/java/gov/nist/csd/pm/epp/functions/ChildOfAssignExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/ChildOfAssignExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,13 +26,11 @@ class ChildOfAssignExecutorTest {
     void TestExec() throws PMException {
         ChildOfAssignExecutor executor = new ChildOfAssignExecutor();
 
-        EventContext eventContext = new AssignEvent(testCtx.getO1(), testCtx.getOa1());
-        String user = testCtx.getU1().getName();
-        String process = "";
+        EventContext eventContext = new AssignEvent(new UserContext(testCtx.getU1().getName()), testCtx.getO1(), testCtx.getOa1());
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(), null);
 
-        Node node = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        Node node = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(node);
         assertEquals(testCtx.getO1(), node);

--- a/src/test/java/gov/nist/csd/pm/epp/functions/CreateNodeExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/CreateNodeExecutorTest.java
@@ -6,6 +6,7 @@ import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.epp.events.ObjectAccessEvent;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -30,8 +31,6 @@ class CreateNodeExecutorTest {
         CreateNodeExecutor executor = new CreateNodeExecutor();
 
         EventContext eventContext = null;
-        String user = testCtx.getU1().getName();
-        String process = "";
         PDP pdp = testCtx.getPdp();
         Function function =
                 new Function(
@@ -43,7 +42,7 @@ class CreateNodeExecutorTest {
                                 new Arg("OA"),
                                 new Arg(new Function("to_props", Arrays.asList(new Arg("k=v"))))));
 
-        Node n = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        Node n = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(n);
         assertEquals("testNode", n.getName());

--- a/src/test/java/gov/nist/csd/pm/epp/functions/CurrentProcessExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/CurrentProcessExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,13 +26,11 @@ class CurrentProcessExecutorTest {
     void TestExec() throws PMException {
         CurrentProcessExecutor executor = new CurrentProcessExecutor();
 
-        EventContext eventContext = new AssignEvent(testCtx.getO1(), testCtx.getOa1());
-        String user = testCtx.getU1().getName();
-        String process = "1234";
+        EventContext eventContext = new AssignEvent(new UserContext(testCtx.getU1().getName(), "1234"), testCtx.getO1(), testCtx.getOa1());
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(), null);
 
-        String result = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        String result = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(result);
         assertEquals("1234", result);

--- a/src/test/java/gov/nist/csd/pm/epp/functions/CurrentTargetExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/CurrentTargetExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
@@ -27,13 +28,11 @@ class CurrentTargetExecutorTest {
     void TestExec() throws PMException {
         CurrentTargetExecutor executor = new CurrentTargetExecutor();
 
-        EventContext eventContext = new AssignEvent(testCtx.getO1(), testCtx.getOa1());
-        String user = testCtx.getU1().getName();
-        String process = "1234";
+        EventContext eventContext = new AssignEvent(new UserContext(testCtx.getU1().getName(), "1234"), testCtx.getO1(), testCtx.getOa1());
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(), null);
 
-        Node target = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        Node target = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(target);
         assertEquals(testCtx.getO1(), target);

--- a/src/test/java/gov/nist/csd/pm/epp/functions/CurrentUserExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/CurrentUserExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
@@ -27,15 +28,13 @@ class CurrentUserExecutorTest {
     void TestExec() throws PMException {
         CurrentUserExecutor executor = new CurrentUserExecutor();
 
-        EventContext eventContext = new AssignEvent(testCtx.getO1(), testCtx.getOa1());
-        String user = testCtx.getU1().getName();
-        String process = "1234";
+        EventContext eventContext = new AssignEvent(new UserContext(testCtx.getU1().getName(), "1234"), testCtx.getO1(), testCtx.getOa1());
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(), null);
 
-        Node userNode = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        Node userNode = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(userNode);
-        assertEquals(user, userNode.getName());
+        assertEquals(testCtx.getU1().getName(), userNode.getName());
     }
 }

--- a/src/test/java/gov/nist/csd/pm/epp/functions/GetChildrenExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/GetChildrenExecutorTest.java
@@ -6,6 +6,7 @@ import gov.nist.csd.pm.epp.events.AssignToEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -32,14 +33,12 @@ class GetChildrenExecutorTest {
     void TestExec() throws PMException {
         GetChildrenExecutor executor = new GetChildrenExecutor();
 
-        EventContext eventContext = new AssignToEvent(testCtx.getOa1(), testCtx.getO1());
-        String user = testCtx.getU1().getName();
-        String process = "1234";
+        EventContext eventContext = new AssignToEvent(new UserContext(testCtx.getU1().getName(), "1234"), testCtx.getOa1(), testCtx.getO1());
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(),
                 Arrays.asList(new Arg("oa1"), new Arg("OA")));
 
-        List<String> children = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        List<String> children = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(children);
         assertEquals(Arrays.asList(testCtx.getO1().getName()), children);

--- a/src/test/java/gov/nist/csd/pm/epp/functions/GetNodeExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/GetNodeExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignToEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -31,13 +32,11 @@ class GetNodeExecutorTest {
         GetNodeExecutor executor = new GetNodeExecutor();
 
         EventContext eventContext = null;
-        String user = testCtx.getU1().getName();
-        String process = "1234";
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(),
                 Arrays.asList(new Arg("oa1"), new Arg("OA")));
 
-        Node node = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        Node node = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(node);
         assertEquals(testCtx.getOa1(), node);

--- a/src/test/java/gov/nist/csd/pm/epp/functions/GetNodeNameExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/GetNodeNameExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignToEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -30,14 +31,12 @@ class GetNodeNameExecutorTest {
     void TestExec() throws PMException {
         GetNodeNameExecutor executor = new GetNodeNameExecutor();
 
-        EventContext eventContext = new AssignToEvent(testCtx.getOa1(), testCtx.getO1());
-        String user = testCtx.getU1().getName();
-        String process = "1234";
+        EventContext eventContext = new AssignToEvent(new UserContext(testCtx.getU1().getName(), "1234"), testCtx.getOa1(), testCtx.getO1());
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(),
                 Arrays.asList(new Arg(new Function("get_node", Arrays.asList(new Arg("oa1"), new Arg("OA"))))));
 
-        String name = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        String name = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(name);
         assertEquals("oa1", name);

--- a/src/test/java/gov/nist/csd/pm/epp/functions/IsNodeContainedInExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/IsNodeContainedInExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignToEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,9 +28,7 @@ class IsNodeContainedInExecutorTest {
     void TestExec() throws PMException {
         IsNodeContainedInExecutor executor = new IsNodeContainedInExecutor();
 
-        EventContext eventContext = new AssignToEvent(testCtx.getOa1(), testCtx.getO1());
-        String user = testCtx.getU1().getName();
-        String process = "1234";
+        EventContext eventContext = new AssignToEvent(new UserContext(testCtx.getU1().getName(), "1234"), testCtx.getOa1(), testCtx.getO1());
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(),
                 Arrays.asList(
@@ -41,7 +40,7 @@ class IsNodeContainedInExecutorTest {
                         )
                 )
         );
-        boolean isContained = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        boolean isContained = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
         assertTrue(isContained);
 
         function = new Function(executor.getFunctionName(),
@@ -54,7 +53,7 @@ class IsNodeContainedInExecutorTest {
                         )
                 )
         );
-        isContained = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        isContained = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
         assertFalse(isContained);
     }
 }

--- a/src/test/java/gov/nist/csd/pm/epp/functions/ParentOfAssignExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/ParentOfAssignExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
 import org.junit.jupiter.api.AfterEach;
@@ -26,13 +27,11 @@ class ParentOfAssignExecutorTest {
     void TestExec() throws PMException {
         ParentOfAssignExecutor executor = new ParentOfAssignExecutor();
 
-        EventContext eventContext = new AssignEvent(testCtx.getO1(), testCtx.getOa1());
-        String user = testCtx.getU1().getName();
-        String process = "";
+        EventContext eventContext = new AssignEvent(new UserContext(testCtx.getU1().getName()), testCtx.getO1(), testCtx.getOa1());
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(), null);
 
-        Node node = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        Node node = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(node);
         assertEquals(testCtx.getOa1(), node);

--- a/src/test/java/gov/nist/csd/pm/epp/functions/TestUtil.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/TestUtil.java
@@ -1,9 +1,11 @@
 package gov.nist.csd.pm.epp.functions;
 
+import gov.nist.csd.pm.epp.EPPOptions;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
 import gov.nist.csd.pm.pap.PAP;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.Graph;
 import gov.nist.csd.pm.pip.graph.MemGraph;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
@@ -15,7 +17,8 @@ import java.util.Random;
 
 class TestUtil {
     static TestContext getTestCtx() throws PMException {
-        Graph graph = new MemGraph();
+        PDP pdp = new PDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), new EPPOptions());
+        Graph graph = pdp.getGraphService(new UserContext("super"));
         Node pc1 = graph.createPolicyClass("pc1", null);
         Node oa1 = graph.createNode("oa1", NodeType.OA, null, pc1.getName());
         Node o1 = graph.createNode("o1", NodeType.O, null, oa1.getName());
@@ -24,8 +27,7 @@ class TestUtil {
 
         graph.associate(ua1.getName(), oa1.getName(), new OperationSet("read", "write"));
 
-        return new TestContext(new PDP(new PAP(graph, new MemProhibitions(), new MemObligations()), null),
-                u1, ua1, o1, oa1, pc1);
+        return new TestContext(pdp, u1, ua1, o1, oa1, pc1);
     }
 
     static class TestContext {

--- a/src/test/java/gov/nist/csd/pm/epp/functions/ToPropertiesExecutorTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/ToPropertiesExecutorTest.java
@@ -5,6 +5,7 @@ import gov.nist.csd.pm.epp.events.AssignEvent;
 import gov.nist.csd.pm.epp.events.EventContext;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pdp.PDP;
+import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.model.functions.Arg;
 import gov.nist.csd.pm.pip.obligations.model.functions.Function;
@@ -30,13 +31,11 @@ class ToPropertiesExecutorTest {
     void TestExec() throws PMException {
         ToPropertiesExecutor executor = new ToPropertiesExecutor();
 
-        EventContext eventContext = new AssignEvent(testCtx.getO1(), testCtx.getOa1());
-        String user = testCtx.getU1().getName();
-        String process = "";
+        EventContext eventContext = null;
         PDP pdp = testCtx.getPdp();
         Function function = new Function(executor.getFunctionName(), Arrays.asList(new Arg("k=v"), new Arg("k1=v1"), new Arg("k2=v2")));
 
-        Map props = executor.exec(eventContext, user, process, pdp, function, new FunctionEvaluator());
+        Map props = executor.exec(new UserContext("super"), eventContext, pdp, function, new FunctionEvaluator());
 
         assertNotNull(props);
         assertEquals(3, props.size());

--- a/src/test/java/gov/nist/csd/pm/pdp/services/GraphServiceTest.java
+++ b/src/test/java/gov/nist/csd/pm/pdp/services/GraphServiceTest.java
@@ -119,13 +119,12 @@ class GraphServiceTest {
         PDP pdp = new PDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), null);
         GraphSerializer.deserialize(pdp.getGraphService(new UserContext("super", "")), s);
 
-        Set<Node> papNodes = pdp.getPAP().getGraphPAP().getNodes();
+        Set<Node> papNodes = pdp.getGraphService(new UserContext("super", "")).getNodes();
         UserContext userContext = new UserContext("super", "");
         Graph graphService = pdp.getGraphService(userContext);
         Set<Node> pdpNodes = graphService.getNodes();
 
-        // -1 because the super user will have access to all nodes except the UA which gives it access to itself (superUA2)
-        assertEquals(papNodes.size()-1, pdpNodes.size());
+        assertEquals(papNodes.size(), pdpNodes.size());
     }
 
 }

--- a/src/test/resources/epp/event_test.yml
+++ b/src/test/resources/epp/event_test.yml
@@ -40,8 +40,8 @@ rules:
                 name: anyUser assign success
                 type:  OA
               where:
-                name: pc1
-                type: PC
+                name: oa2
+                type: OA
   - label: anyUser in list deassign
     event:
       subject:
@@ -61,5 +61,5 @@ rules:
                 name: anyUser in list deassign success
                 type: OA
               where:
-                name: pc1
-                type: PC
+                name: oa2
+                type: OA


### PR DESCRIPTION
- Removes the getPAP method in the PDP and EPP so there is no way to bypass the decision point.
- Clarify that the user in the EPP is the user that created the obligation.  In addition, the user that performs the event has been moved to the Event classes.