### PR TITLE
fix access denied string

### DIFF
--- a/src/main/java/gov/nist/csd/pm/epp/events/EventContext.java
+++ b/src/main/java/gov/nist/csd/pm/epp/events/EventContext.java
@@ -9,7 +9,7 @@ public class EventContext {
     public static final String ASSIGN_EVENT = "assign";
     public static final String DEASSIGN_FROM_EVENT = "deassign from";
     public static final String DEASSIGN_EVENT = "deassign";
-    public static final String ACCESS_DENIED_EVENT = "deassign";
+    public static final String ACCESS_DENIED_EVENT = "access denied";
 
     private UserContext userCtx;
     private String event;


### PR DESCRIPTION
fixes #62 

Fixed a typo where the ACCESS_DENIED_EVENT constant was given the wrong value.