### PR TITLE
Refactor epp pdp

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,12 @@ PAP pap = new PAP(graph, prohibitions, obligations);
 
 ### Policy Decision Point (PDP)
 The PDP implements the same interfaces in the PIP but provides a layer of access control to restrict access to the administrative commands of the PAP.
+Use the static PDP.newPDP() method to create a new PDP and initialize it's EPP reference.  The static method is used because there
+is a circular dependency between the PDP and EPP and a specific series of steps is required to properly initialize both.
 
+The *EPP* will be available via `pdp.getEPP()`
 ```java
-PDP pdp = new PDP(pap, new EPPOptions());
+PDP pdp = PDP.newPDP(pap, eppOptions, resourceOps)
 
 // access the PDP's GraphService (which sits in front of the Graph made earlier) as u1
 // we'll provide an empty process identifier for this example
@@ -286,9 +289,9 @@ Obligation obligation = EVRParser.parse(is);
 
 Obligations obligations = new MemObligations();
 
-PDP pdp = new PDP(graph, new MemProhibitions(), obligations);
+PDP pdp = PDP.newPDP(pap, eppOptions, resourceOps)
 // add the obligation and enable it
-pdp.getPAP().getObligationsPAP().add(obligation, true);
+pdp.getObligationsServiceadd(obligation, true);
 ```
 
 #### Processing Event

--- a/src/main/java/gov/nist/csd/pm/epp/EPP.java
+++ b/src/main/java/gov/nist/csd/pm/epp/EPP.java
@@ -29,13 +29,7 @@ public class EPP {
     private PDP pdp;
     private FunctionEvaluator functionEvaluator;
 
-    public EPP(PDP pdp, PAP pap) throws PMException {
-        this.pap = pap;
-        this.pdp = pdp;
-        this.functionEvaluator = new FunctionEvaluator();
-    }
-
-    public EPP(PDP pdp, PAP pap, EPPOptions eppOptions) throws PMException {
+    public EPP(PAP pap, PDP pdp, EPPOptions eppOptions) throws PMException {
         this.pap = pap;
         this.pdp = pdp;
         this.functionEvaluator = new FunctionEvaluator();

--- a/src/main/java/gov/nist/csd/pm/pdp/PDP.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/PDP.java
@@ -33,7 +33,7 @@ public class PDP {
      * @throws PMException if there is an error initializing the EPP.
      */
     public PDP(PAP pap, EPPOptions eppOptions, OperationSet resourceOps) throws PMException {
-        this.epp = new EPP(this, pap, eppOptions);
+        this.epp = new EPP(new PDP(pap, eppOptions, resourceOps), pap, eppOptions);
 
         // initialize services
         this.graphService = new GraphService(pap, this.epp, resourceOps);

--- a/src/test/java/gov/nist/csd/pm/epp/EPPTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/EPPTest.java
@@ -38,7 +38,7 @@ class EPPTest {
 
     @BeforeEach
     void setup() throws PMException {
-        pdp = new PDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), new EPPOptions(), new OperationSet("read", "write", "execute"));
+        pdp = PDP.newPDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), new EPPOptions(), new OperationSet("read", "write", "execute"));
         Graph graph = pdp.getGraphService(new UserContext("super"));
         pc1 = graph.createPolicyClass("pc1", null);
         oa1 = graph.createNode("oa1", NodeType.OA, null, pc1.getName());
@@ -131,7 +131,7 @@ class EPPTest {
         Obligations obligations = new MemObligations();
         obligations.add(obligation, true);
 
-        PDP pdp = new PDP(new PAP(graph, new MemProhibitions(), obligations), new EPPOptions(), new OperationSet("read", "write", "execute"));
+        PDP pdp = PDP.newPDP(new PAP(graph, new MemProhibitions(), obligations), new EPPOptions(), new OperationSet("read", "write", "execute"));
         pdp.getEPP().processEvent(new AssignToEvent(new UserContext("u1"), oa2, o1));
 
         assertTrue(graph.exists("new OA"));

--- a/src/test/java/gov/nist/csd/pm/epp/functions/TestUtil.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/TestUtil.java
@@ -17,7 +17,7 @@ import java.util.Random;
 
 class TestUtil {
     static TestContext getTestCtx() throws PMException {
-        PDP pdp = new PDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), new EPPOptions(), new OperationSet("read", "write", "execute"));
+        PDP pdp = PDP.newPDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), new EPPOptions(), new OperationSet("read", "write", "execute"));
         Graph graph = pdp.getGraphService(new UserContext("super"));
         Node pc1 = graph.createPolicyClass("pc1", null);
         Node oa1 = graph.createNode("oa1", NodeType.OA, null, pc1.getName());

--- a/src/test/java/gov/nist/csd/pm/pdp/services/GraphServiceTest.java
+++ b/src/test/java/gov/nist/csd/pm/pdp/services/GraphServiceTest.java
@@ -18,7 +18,7 @@ class GraphServiceTest {
 
     @Test
     void testPolicyClassReps() throws PMException {
-        PDP pdp = new PDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), null, new OperationSet("read", "write", "execute"));
+        PDP pdp = PDP.newPDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), null, new OperationSet("read", "write", "execute"));
         Graph graph = pdp.getGraphService(new UserContext("super", ""));
 
         Node test = graph.createPolicyClass("test", null);


### PR DESCRIPTION
fixes #63 

Use a static method to initialize the PDP and EPP.  This is because there is a circular dependency between the PDP and EPP. In order to initialize both without causing a possible race condition is to execute a specific series of steps to initialize both every time.