### PR TITLE
Move graph config to pap

### DIFF
--- a/src/main/java/gov/nist/csd/pm/epp/EPP.java
+++ b/src/main/java/gov/nist/csd/pm/epp/EPP.java
@@ -457,7 +457,7 @@ public class EPP {
         }
     }
 
-    private void createRule(String obligationLabel, EventContext eventCtx, Rule rule) {
+    private void createRule(String obligationLabel, EventContext eventCtx, Rule rule) throws PMException {
         // add the rule to the obligation
         Obligation obligation = pap.getObligationsAdmin().get(obligationLabel);
         List<Rule> rules = obligation.getRules();

--- a/src/main/java/gov/nist/csd/pm/operations/Operations.java
+++ b/src/main/java/gov/nist/csd/pm/operations/Operations.java
@@ -41,10 +41,13 @@ public class Operations {
     public static final String GET_ACCESSIBLE_CHILDREN    = "get accessible children";
     public static final String GET_PROHIBITED_OPS         = "get prohibited ops";
     public static final String GET_ACCESSIBLE_NODES       = "get accessible nodes";
-    public static final String PROHIBIT_SUBJECT           = "prohibit subject";
-    public static final String PROHIBIT_RESOURCE          = "prohibit resource";
     public static final String TO_JSON                    = "to json";
     public static final String FROM_JSON                  = "from json";
+    public static final String ADD_OBLIGATION             = "add obligation";
+    public static final String GET_OBLIGATION             = "get obligation";
+    public static final String UPDATE_OBLIGATION          = "update obligation";
+    public static final String DELETE_OBLIGATION          = "delete obligation";
+    public static final String ENABLE_OBLIGATION          = "enable obligation";
 
     public static final String ALL_OPS = "*";
     public static final String ALL_ADMIN_OPS = "*a";
@@ -77,10 +80,16 @@ public class Operations {
             GET_ACCESSIBLE_CHILDREN,
             GET_PROHIBITED_OPS,
             GET_ACCESSIBLE_NODES,
-            PROHIBIT_SUBJECT,
-            PROHIBIT_RESOURCE,
             RESET,
             TO_JSON,
-            FROM_JSON
+            FROM_JSON,
+            UPDATE_PROHIBITION,
+            DELETE_PROHIBITION,
+            VIEW_PROHIBITION,
+            ADD_OBLIGATION,
+            GET_OBLIGATION,
+            UPDATE_OBLIGATION,
+            DELETE_OBLIGATION,
+            ENABLE_OBLIGATION
     );
 }

--- a/src/main/java/gov/nist/csd/pm/operations/Operations.java
+++ b/src/main/java/gov/nist/csd/pm/operations/Operations.java
@@ -35,11 +35,16 @@ public class Operations {
     public static final String RESET                      = "reset";
     public static final String GET_PERMISSIONS            = "get permissions";
     public static final String CREATE_PROHIBITION         = "create prohibition";
+    public static final String UPDATE_PROHIBITION         = "update prohibition";
+    public static final String VIEW_PROHIBITION           = "view prohibition";
+    public static final String DELETE_PROHIBITION         = "delete prohibition";
     public static final String GET_ACCESSIBLE_CHILDREN    = "get accessible children";
     public static final String GET_PROHIBITED_OPS         = "get prohibited ops";
     public static final String GET_ACCESSIBLE_NODES       = "get accessible nodes";
     public static final String PROHIBIT_SUBJECT           = "prohibit subject";
     public static final String PROHIBIT_RESOURCE          = "prohibit resource";
+    public static final String TO_JSON                    = "to json";
+    public static final String FROM_JSON                  = "from json";
 
     public static final String ALL_OPS = "*";
     public static final String ALL_ADMIN_OPS = "*a";
@@ -74,6 +79,8 @@ public class Operations {
             GET_ACCESSIBLE_NODES,
             PROHIBIT_SUBJECT,
             PROHIBIT_RESOURCE,
-            RESET
+            RESET,
+            TO_JSON,
+            FROM_JSON
     );
 }

--- a/src/main/java/gov/nist/csd/pm/pap/GraphAdmin.java
+++ b/src/main/java/gov/nist/csd/pm/pap/GraphAdmin.java
@@ -1,0 +1,271 @@
+package gov.nist.csd.pm.pap;
+
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.policies.SuperPolicy;
+import gov.nist.csd.pm.pip.graph.Graph;
+import gov.nist.csd.pm.pip.graph.model.nodes.Node;
+import gov.nist.csd.pm.pip.graph.model.nodes.NodeType;
+import gov.nist.csd.pm.pip.graph.model.relationships.Assignment;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static gov.nist.csd.pm.operations.Operations.ALL_OPS;
+import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.*;
+import static gov.nist.csd.pm.pip.graph.model.nodes.Properties.NAMESPACE_PROPERTY;
+import static gov.nist.csd.pm.pip.graph.model.nodes.Properties.REP_PROPERTY;
+
+public class GraphAdmin implements Graph {
+
+    private Graph graph;
+    private SuperPolicy superPolicy;
+
+    public GraphAdmin(Graph graph) throws PMException {
+        this.graph = graph;
+        this.superPolicy = new SuperPolicy();
+        this.superPolicy.configure(this.graph);
+    }
+
+    public SuperPolicy getSuperPolicy() {
+        return superPolicy;
+    }
+
+    @Override
+    public Node createPolicyClass(String name, Map<String, String> properties) throws PMException {
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
+
+        String rep = name + "_rep";
+        String defaultUA = name + "_default_UA";
+        String defaultOA = name + "_default_OA";
+
+        properties.putAll(Node.toProperties("default_ua", defaultUA, "default_oa", defaultOA,
+                REP_PROPERTY, rep));
+
+        // create the pc node
+        Node pcNode = graph.createPolicyClass(name, properties);
+
+        // create the PC UA node
+        Node pcUANode = graph.createNode(defaultUA, UA, Node.toProperties(NAMESPACE_PROPERTY, name), pcNode.getName());
+        // create the PC OA node
+        Node pcOANode = graph.createNode(defaultOA, OA, Node.toProperties(NAMESPACE_PROPERTY, name), pcNode.getName());
+
+        // assign Super U to PC UA
+        // getPAP().getGraphPAP().assign(superPolicy.getSuperU().getID(), pcUANode.getID());
+        // assign superUA and superUA2 to PC
+        graph.assign(superPolicy.getSuperUserAttribute().getName(), pcNode.getName());
+        graph.assign(superPolicy.getSuperUserAttribute2().getName(), pcNode.getName());
+        // associate Super UA and PC UA
+        graph.associate(superPolicy.getSuperUserAttribute().getName(), pcUANode.getName(), new OperationSet(ALL_OPS));
+        // associate Super UA and PC OA
+        graph.associate(superPolicy.getSuperUserAttribute().getName(), pcOANode.getName(), new OperationSet(ALL_OPS));
+
+        // create an OA that will represent the pc
+        graph.createNode(rep, OA, Node.toProperties("pc", String.valueOf(name)),
+                superPolicy.getSuperObjectAttribute().getName());
+
+        return pcNode;
+    }
+
+    @Override
+    public Node createNode(String name, NodeType type, Map<String, String> properties, String initialParent, String... additionalParents) throws PMException {
+        if (name == null) {
+            throw new IllegalArgumentException("a node cannot have a null name");
+        } else if (type == null) {
+            throw new IllegalArgumentException("a node cannot have a null type");
+        } else if (type == PC) {
+            throw new IllegalArgumentException("use cretePolicyClass to crete policy classes");
+        }
+
+        // instantiate the properties map if it's null
+        // if this node is a user, hash the password if present in the properties
+        if(properties == null) {
+            properties = new HashMap<>();
+        }
+
+        NodeType defaultType = (type == OA || type == O) ? OA : UA;
+
+        // if the parent is a PC get the PC default
+        Node parentNode = graph.getNode(initialParent);
+        if (parentNode.getType().equals(PC)) {
+            initialParent = getPolicyClassDefault(parentNode.getName(), defaultType);
+        }
+
+        for (int i = 0; i < additionalParents.length; i++) {
+            String parent = additionalParents[i];
+
+            // if the parent is a PC get the PC default attribute
+            Node additionalParentNode = graph.getNode(parent);
+            if (additionalParentNode.getType().equals(PC)) {
+                additionalParents[i] = getPolicyClassDefault(additionalParentNode.getName(), defaultType);
+            }
+        }
+
+        return graph.createNode(name, type, properties, initialParent, additionalParents);
+    }
+
+    public String getPolicyClassDefault(String pc, NodeType type) {
+        return pc + "_default_" + type.toString();
+    }
+
+    @Override
+    public void updateNode(String name, Map<String, String> properties) throws PMException {
+        graph.updateNode(name, properties);
+    }
+
+    @Override
+    public void deleteNode(String name) throws PMException {
+        graph.deleteNode(name);
+    }
+
+    @Override
+    public boolean exists(String name) throws PMException {
+        return graph.exists(name);
+    }
+
+    @Override
+    public Set<String> getPolicyClasses() throws PMException {
+        return graph.getPolicyClasses();
+    }
+
+    @Override
+    public Set<Node> getNodes() throws PMException {
+        return graph.getNodes();
+    }
+
+    @Override
+    public Node getNode(String name) throws PMException {
+        if(!exists(name)) {
+            throw new PMException(String.format("node %s could not be found", name));
+        }
+
+        return graph.getNode(name);
+    }
+
+    @Override
+    public Node getNode(NodeType type, Map<String, String> properties) throws PMException {
+        return graph.getNode(type, properties);
+    }
+
+    @Override
+    public Set<Node> search(NodeType type, Map<String, String> properties) throws PMException {
+        return graph.search(type, properties);
+    }
+
+    @Override
+    public Set<String> getChildren(String name) throws PMException {
+        return graph.getChildren(name);
+    }
+
+    @Override
+    public Set<String> getParents(String name) throws PMException {
+        return graph.getParents(name);
+    }
+
+    @Override
+    public void assign(String child, String parent) throws PMException {
+        // check that the nodes are not null
+        if(child == null) {
+            throw new IllegalArgumentException("the child node name cannot be null when creating an assignment");
+        } else if(parent == null) {
+            throw new IllegalArgumentException("the parent node name cannot be null when creating an assignment");
+        } else if(!exists(child)) {
+            throw new PMException(String.format("child node %s does not exist", child));
+        } else if(!exists(parent)) {
+            throw new PMException(String.format("parent node %s does not exist", parent));
+        }
+
+        //check if the assignment is valid
+        Node childNode = getNode(child);
+        Node parentNode = getNode(parent);
+        Assignment.checkAssignment(childNode.getType(), parentNode.getType());
+
+        if (parentNode.getType().equals(PC)) {
+            parent = getPolicyClassDefault(parentNode.getName(), childNode.getType());
+        }
+
+        graph.assign(child, parent);
+    }
+
+    @Override
+    public void deassign(String child, String parent) throws PMException {
+        // check that the parameters are correct
+        if(child == null) {
+            throw new IllegalArgumentException("the child node cannot be null when deassigning");
+        } else if(parent == null) {
+            throw new IllegalArgumentException("the parent node cannot be null when deassigning");
+        } else if(!exists(child)) {
+            throw new PMException(String.format("child node %s could not be found when deassigning", child));
+        } else if(!exists(parent)) {
+            throw new PMException(String.format("parent node %s could not be found when deassigning", parent));
+        }
+
+        graph.deassign(child, parent);
+    }
+
+    @Override
+    public boolean isAssigned(String child, String parent) throws PMException {
+        return graph.isAssigned(child, parent);
+    }
+
+    @Override
+    public void associate(String ua, String target, OperationSet operations) throws PMException {
+        if(ua == null) {
+            throw new IllegalArgumentException("the user attribute cannot be null when creating an association");
+        } else if(target == null) {
+            throw new IllegalArgumentException("the target node cannot be null when creating an association");
+        } else if(!exists(ua)) {
+            throw new PMException(String.format("node %s could not be found when creating an association", ua));
+        } else if(!exists(target)) {
+            throw new PMException(String.format("node %s could not be found when creating an association", target));
+        }
+
+        graph.associate(ua, target, operations);
+    }
+
+    @Override
+    public void dissociate(String ua, String target) throws PMException {
+        if(ua == null) {
+            throw new IllegalArgumentException("the user attribute cannot be null when creating an association");
+        } else if(target == null) {
+            throw new IllegalArgumentException("the target cannot be null when creating an association");
+        } else if(!exists(ua)) {
+            throw new PMException(String.format("node %s could not be found when deleting an association", ua));
+        } else if(!exists(target)) {
+            throw new PMException(String.format("node %s could not be found when deleting an association", target));
+        }
+
+        graph.dissociate(ua, target);
+    }
+
+    @Override
+    public Map<String, OperationSet> getSourceAssociations(String source) throws PMException {
+        if(!exists(source)) {
+            throw new PMException(String.format("node %s could not be found", source));
+        }
+
+        return graph.getSourceAssociations(source);
+    }
+
+    @Override
+    public Map<String, OperationSet> getTargetAssociations(String target) throws PMException {
+        if(!exists(target)) {
+            throw new PMException(String.format("node %s could not be found", target));
+        }
+
+        return graph.getTargetAssociations(target);
+    }
+
+    @Override
+    public String toJson() throws PMException {
+        return graph.toJson();
+    }
+
+    @Override
+    public void fromJson(String s) throws PMException {
+        graph.fromJson(s);
+    }
+}

--- a/src/main/java/gov/nist/csd/pm/pap/ObligationsAdmin.java
+++ b/src/main/java/gov/nist/csd/pm/pap/ObligationsAdmin.java
@@ -16,36 +16,36 @@ public class ObligationsAdmin implements Obligations {
 
     @Override
     public void add(Obligation obligation, boolean enable) throws PMException {
-
+        obligations.add(obligation, enable);
     }
 
     @Override
-    public Obligation get(String label) {
-        return null;
+    public Obligation get(String label) throws PMException {
+        return obligations.get(label);
     }
 
     @Override
-    public List<Obligation> getAll() {
-        return null;
+    public List<Obligation> getAll() throws PMException {
+        return obligations.getAll();
     }
 
     @Override
-    public void update(String label, Obligation obligation) {
-
+    public void update(String label, Obligation obligation) throws PMException {
+        obligations.update(label, obligation);
     }
 
     @Override
-    public void delete(String label) {
-
+    public void delete(String label) throws PMException {
+        obligations.delete(label);
     }
 
     @Override
-    public void setEnable(String label, boolean enabled) {
-
+    public void setEnable(String label, boolean enabled) throws PMException {
+        obligations.setEnable(label, enabled);
     }
 
     @Override
-    public List<Obligation> getEnabled() {
-        return null;
+    public List<Obligation> getEnabled() throws PMException {
+        return obligations.getEnabled();
     }
 }

--- a/src/main/java/gov/nist/csd/pm/pap/ObligationsAdmin.java
+++ b/src/main/java/gov/nist/csd/pm/pap/ObligationsAdmin.java
@@ -1,0 +1,51 @@
+package gov.nist.csd.pm.pap;
+
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.pip.obligations.Obligations;
+import gov.nist.csd.pm.pip.obligations.model.Obligation;
+
+import java.util.List;
+
+public class ObligationsAdmin implements Obligations {
+
+    private Obligations obligations;
+
+    public ObligationsAdmin(Obligations obligations) {
+        this.obligations = obligations;
+    }
+
+    @Override
+    public void add(Obligation obligation, boolean enable) throws PMException {
+
+    }
+
+    @Override
+    public Obligation get(String label) {
+        return null;
+    }
+
+    @Override
+    public List<Obligation> getAll() {
+        return null;
+    }
+
+    @Override
+    public void update(String label, Obligation obligation) {
+
+    }
+
+    @Override
+    public void delete(String label) {
+
+    }
+
+    @Override
+    public void setEnable(String label, boolean enabled) {
+
+    }
+
+    @Override
+    public List<Obligation> getEnabled() {
+        return null;
+    }
+}

--- a/src/main/java/gov/nist/csd/pm/pap/PAP.java
+++ b/src/main/java/gov/nist/csd/pm/pap/PAP.java
@@ -7,37 +7,37 @@ import gov.nist.csd.pm.pip.prohibitions.Prohibitions;
 
 public class PAP {
 
-    private Graph        graphPAP;
-    private Prohibitions prohibitionsPAP;
-    private Obligations  obligationsPAP;
+    private GraphAdmin        graphAdmin;
+    private ProhibitionsAdmin prohibitionsAdmin;
+    private ObligationsAdmin  obligationsAdmin;
 
-    public PAP(Graph graphPAP, Prohibitions prohibitionsPAP, Obligations obligationsPAP) throws PMException {
-        this.graphPAP = graphPAP;
-        this.prohibitionsPAP = prohibitionsPAP;
-        this.obligationsPAP = obligationsPAP;
+    public PAP(GraphAdmin graphAdmin, ProhibitionsAdmin prohibitionsAdmin, ObligationsAdmin obligationsAdmin) throws PMException {
+        this.graphAdmin = graphAdmin;
+        this.prohibitionsAdmin = prohibitionsAdmin;
+        this.obligationsAdmin = obligationsAdmin;
     }
 
-    public Graph getGraphPAP() {
-        return graphPAP;
+    public GraphAdmin getGraphAdmin() {
+        return graphAdmin;
     }
 
-    public void setGraphPAP(Graph graphPAP) {
-        this.graphPAP = graphPAP;
+    public void setGraphAdmin(GraphAdmin graphAdmin) {
+        this.graphAdmin = graphAdmin;
     }
 
-    public Prohibitions getProhibitionsPAP() {
-        return prohibitionsPAP;
+    public ProhibitionsAdmin getProhibitionsAdmin() {
+        return prohibitionsAdmin;
     }
 
-    public void setProhibitionsPAP(Prohibitions prohibitionsPAP) {
-        this.prohibitionsPAP = prohibitionsPAP;
+    public void setProhibitionsAdmin(ProhibitionsAdmin prohibitionsAdmin) {
+        this.prohibitionsAdmin = prohibitionsAdmin;
     }
 
-    public Obligations getObligationsPAP() {
-        return obligationsPAP;
+    public ObligationsAdmin getObligationsAdmin() {
+        return obligationsAdmin;
     }
 
-    public void setObligationsPAP(Obligations obligationsPAP) {
-        this.obligationsPAP = obligationsPAP;
+    public void setObligationsAdmin(ObligationsAdmin obligationsAdmin) {
+        this.obligationsAdmin = obligationsAdmin;
     }
 }

--- a/src/main/java/gov/nist/csd/pm/pap/ProhibitionsAdmin.java
+++ b/src/main/java/gov/nist/csd/pm/pap/ProhibitionsAdmin.java
@@ -1,0 +1,60 @@
+package gov.nist.csd.pm.pap;
+
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.pip.prohibitions.Prohibitions;
+import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
+
+import java.util.List;
+
+public class ProhibitionsAdmin implements Prohibitions {
+
+    private Prohibitions prohibitions;
+
+    public ProhibitionsAdmin(Prohibitions prohibitions) {
+        this.prohibitions = prohibitions;
+    }
+
+    @Override
+    public void add(Prohibition prohibition) throws PMException {
+        String name = prohibition.getName();
+
+        //check that the prohibition name is not null or empty
+        if(name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("a null name was provided when creating a prohibition");
+        }
+
+        //check the prohibitions doesn't already exist
+        for(Prohibition p : getAll()) {
+            if(p.getName().equals(name)) {
+                throw new PMException(String.format("a prohibition with the name %s already exists", name));
+            }
+        }
+
+        prohibitions.add(prohibition);
+    }
+
+    @Override
+    public List<Prohibition> getAll() throws PMException {
+        return prohibitions.getAll();
+    }
+
+    @Override
+    public Prohibition get(String prohibitionName) throws PMException {
+        return prohibitions.get(prohibitionName);
+    }
+
+    @Override
+    public List<Prohibition> getProhibitionsFor(String subject) throws PMException {
+        return prohibitions.getProhibitionsFor(subject);
+    }
+
+    @Override
+    public void update(String prohibitionName, Prohibition prohibition) throws PMException {
+        prohibitions.update(prohibitionName, prohibition);
+    }
+
+    @Override
+    public void delete(String prohibitionName) throws PMException {
+        prohibitions.delete(prohibitionName);
+    }
+}

--- a/src/main/java/gov/nist/csd/pm/pap/policies/SuperPolicy.java
+++ b/src/main/java/gov/nist/csd/pm/pap/policies/SuperPolicy.java
@@ -1,4 +1,4 @@
-package gov.nist.csd.pm.pdp.policy;
+package gov.nist.csd.pm.pap.policies;
 
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
@@ -15,7 +15,7 @@ import static gov.nist.csd.pm.pip.graph.model.nodes.Properties.REP_PROPERTY;
 
 public class SuperPolicy {
 
-    private static final Node superUser = new Node("super", U, Node.toProperties(NAMESPACE_PROPERTY, "super"));
+    private final Node superUser = new Node("super", U, Node.toProperties(NAMESPACE_PROPERTY, "super"));
     private Node superUA1;
     private Node superUA2;
     private Node superPolicyClassRep;
@@ -97,33 +97,32 @@ public class SuperPolicy {
         if(!children.contains(superUA2.getName())) {
             graph.assign(superUA2.getName(), superPC.getName());
         }
-        // check super ua2 is assigned to super pc
-        children = graph.getChildren(superPC.getName());
-        if(!children.contains(superUA2.getName())) {
-            graph.assign(superUA2.getName(), superPC.getName());
-        }
+
         // check super user is assigned to super ua1
         children = graph.getChildren(superUA1.getName());
         if(!children.contains(superUser.getName())) {
             graph.assign(superUser.getName(), superUA1.getName());
         }
+
         // check super user is assigned to super ua2
         children = graph.getChildren(superUA2.getName());
         if(!children.contains(superUser.getName())) {
             graph.assign(superUser.getName(), superUA2.getName());
         }
+
         // check super oa is assigned to super pc
         children = graph.getChildren(superPC.getName());
         if(!children.contains(superOA.getName())) {
             graph.assign(superOA.getName(), superPC.getName());
         }
+
         // check super o is assigned to super oa
         children = graph.getChildren(superOA.getName());
         if(!children.contains(superPolicyClassRep.getName())) {
             graph.assign(superPolicyClassRep.getName(), superOA.getName());
         }
 
-        // associate super ua to super oa
+        // associate super_ua1 to super_oa and super_ua2 to super_ua1
         graph.associate(superUA1.getName(), superOA.getName(), new OperationSet(ALL_OPS));
         graph.associate(superUA2.getName(), superUA1.getName(), new OperationSet(ALL_OPS));
 
@@ -161,13 +160,18 @@ public class SuperPolicy {
                 graph.assign(superUA2.getName(), pc);
             }
 
-            // associate super ua 1 with pc default node
+            // associate super ua 1 with pc default nodes
             graph.associate(superUA1.getName(), defaultUA, new OperationSet(ALL_OPS));
             graph.associate(superUA1.getName(), defaultOA, new OperationSet(ALL_OPS));
 
             // create the rep
             if (!graph.exists(rep)) {
                 graph.createNode(rep, OA, Node.toProperties("pc", pc), superOA.getName());
+            } else {
+                // check that the rep is assigned to the super OA
+                if (!graph.isAssigned(rep, superOA.getName())) {
+                    graph.assign(rep, superOA.getName());
+                }
             }
         }
     }

--- a/src/main/java/gov/nist/csd/pm/pdp/PDP.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/PDP.java
@@ -2,18 +2,14 @@ package gov.nist.csd.pm.pdp;
 
 import gov.nist.csd.pm.epp.EPP;
 import gov.nist.csd.pm.epp.EPPOptions;
-import gov.nist.csd.pm.epp.functions.FunctionExecutor;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
 import gov.nist.csd.pm.pap.PAP;
-import gov.nist.csd.pm.pdp.policy.SuperPolicy;
+import gov.nist.csd.pm.pap.policies.SuperPolicy;
 import gov.nist.csd.pm.pdp.services.*;
 import gov.nist.csd.pm.pip.graph.Graph;
-import gov.nist.csd.pm.pip.graph.GraphSerializer;
 import gov.nist.csd.pm.pip.obligations.Obligations;
 import gov.nist.csd.pm.pip.prohibitions.Prohibitions;
-
-import java.util.Set;
 
 public class PDP {
 
@@ -65,12 +61,9 @@ public class PDP {
     private void initServices() throws PMException {
         // initialize services
         this.graphService = new GraphService(pap, this.epp, resourceOps);
-        // configure the super policy
-        SuperPolicy superPolicy = this.graphService.configureSuperPolicy();
-
-        this.prohibitionsService = new ProhibitionsService(pap, this.epp, resourceOps, superPolicy);
+        this.prohibitionsService = new ProhibitionsService(pap, this.epp, resourceOps);
         this.analyticsService = new AnalyticsService(pap, this.epp, resourceOps);
-        this.obligationsService = new ObligationsService(pap, this.epp, resourceOps, superPolicy);
+        this.obligationsService = new ObligationsService(pap, this.epp, resourceOps);
     }
 
     public EPP getEPP() {

--- a/src/main/java/gov/nist/csd/pm/pdp/services/AnalyticsService.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/AnalyticsService.java
@@ -64,7 +64,7 @@ public class AnalyticsService extends Service {
                 // if the set of required PCs is a subset of the actual pcset,
                 // then user u has some privileges on the current oa node.
                 if (hsActualPcs.containsAll(hsReqPcs)) {
-                    hsOa.add(getGraphPAP().getNode(oa));
+                    hsOa.add(getGraphAdmin().getNode(oa));
                     break;
                 }
             }
@@ -86,7 +86,7 @@ public class AnalyticsService extends Service {
         String crtNode;
 
         // Get u's directly assigned attributes and put them into the queue.
-        Set<String> hsAttrs = getGraphPAP().getParents(userCtx.getUser());
+        Set<String> hsAttrs = getGraphAdmin().getParents(userCtx.getUser());
         List<String> queue = new ArrayList<>(hsAttrs);
 
         // While the queue has elements, extract an element from the queue
@@ -104,7 +104,7 @@ public class AnalyticsService extends Service {
 
                     // Find the opsets of this user attribute. Note that the set of containers for this
                     // node (user attribute) may contain not only opsets.
-                    Map<String, OperationSet> assocs = getGraphPAP().getSourceAssociations(crtNode);
+                    Map<String, OperationSet> assocs = getGraphAdmin().getSourceAssociations(crtNode);
 
                     // Go through the containers and only for opsets do the following.
                     // For each opset ops of ua:
@@ -155,7 +155,7 @@ public class AnalyticsService extends Service {
                 }
                 visited.add(crtNode);
 
-                Set<String> hsDescs = getGraphPAP().getParents(crtNode);
+                Set<String> hsDescs = getGraphAdmin().getParents(crtNode);
                 queue.addAll(hsDescs);
             }
         }
@@ -196,7 +196,7 @@ public class AnalyticsService extends Service {
         // Insert the start node into the queue
         queue.add(node);
 
-        Set<String> policyClasses = getGraphPAP().getPolicyClasses();
+        Set<String> policyClasses = getGraphAdmin().getPolicyClasses();
 
         // While queue is not empty
         while (!queue.isEmpty()) {
@@ -209,7 +209,7 @@ public class AnalyticsService extends Service {
                 // Extract its direct descendants. If a descendant is an attribute,
                 // insert it into the queue. If it is a pc, add it to reachable,
                 // if not already there
-                Set<String> hsContainers = getGraphPAP().getParents(crtNode);
+                Set<String> hsContainers = getGraphAdmin().getParents(crtNode);
                 for (String n : hsContainers) {
                     if (policyClasses.contains(n)) {
                         reachable.add(n);
@@ -223,11 +223,11 @@ public class AnalyticsService extends Service {
     }
 
     private boolean inMemUattrHasOpsets(String uaNode) throws PMException {
-        return !getGraphPAP().getSourceAssociations(uaNode).isEmpty();
+        return !getGraphAdmin().getSourceAssociations(uaNode).isEmpty();
     }
 
     public Explain explain(String user, String target) throws PMException {
-        Auditor auditor = new PReviewAuditor(getGraphPAP(), getResourceOps());
+        Auditor auditor = new PReviewAuditor(getGraphAdmin(), getResourceOps());
         return auditor.explain(user, target);
     }
 }

--- a/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
@@ -9,7 +9,7 @@ import gov.nist.csd.pm.exceptions.PMAuthorizationException;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
 import gov.nist.csd.pm.pap.PAP;
-import gov.nist.csd.pm.pdp.policy.SuperPolicy;
+import gov.nist.csd.pm.pdp.services.guard.GraphGuard;
 import gov.nist.csd.pm.pip.graph.Graph;
 import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.graph.model.nodes.NodeType;
@@ -29,58 +29,21 @@ import static gov.nist.csd.pm.pip.graph.model.nodes.Properties.*;
 public class GraphService extends Service implements Graph {
 
     private Graph graph;
+    private GraphGuard guard;
 
     public GraphService(PAP pap, EPP epp, OperationSet resourceOps) throws PMException {
         super(pap, epp, resourceOps);
-
-        this.graph = pap.getGraphPAP();
-    }
-
-    public SuperPolicy configureSuperPolicy() throws PMException {
-        superPolicy = new SuperPolicy();
-        superPolicy.configure(graph);
-        return superPolicy;
+        this.graph = pap.getGraphAdmin();
+        this.guard = new GraphGuard(pap, resourceOps);
     }
 
     @Override
     public Node createPolicyClass(String name, Map<String, String> properties) throws PMException {
-        // check that the user can create a policy class
-        if (!hasPermissions(userCtx, superPolicy.getSuperPolicyClassRep().getName(), CREATE_POLICY_CLASS)) {
-            throw new PMAuthorizationException("unauthorized permissions to create a policy class");
-        }
+        // check user has permission to create a policy class
+        guard.checkCreatePolicyClass(userCtx);
 
-        if (properties == null) {
-            properties = new HashMap<>();
-        }
-
-        // create the PC node
-        String rep = name + "_rep";
-        String defaultUA = name + "_default_UA";
-        String defaultOA = name + "_default_OA";
-
-        properties.putAll(Node.toProperties("default_ua", defaultUA, "default_oa", defaultOA,
-                REP_PROPERTY, rep));
-        Node pcNode = getPAP().getGraphPAP().createPolicyClass(name, properties);
-        // create the PC UA node
-        Node pcUANode = getPAP().getGraphPAP().createNode(defaultUA, UA, Node.toProperties(NAMESPACE_PROPERTY, name), pcNode.getName());
-        // create the PC OA node
-        Node pcOANode = getPAP().getGraphPAP().createNode(defaultOA, OA, Node.toProperties(NAMESPACE_PROPERTY, name), pcNode.getName());
-
-        // assign Super U to PC UA
-        // getPAP().getGraphPAP().assign(superPolicy.getSuperU().getID(), pcUANode.getID());
-        // assign superUA and superUA2 to PC
-        getPAP().getGraphPAP().assign(superPolicy.getSuperUserAttribute().getName(), pcNode.getName());
-        getPAP().getGraphPAP().assign(superPolicy.getSuperUserAttribute2().getName(), pcNode.getName());
-        // associate Super UA and PC UA
-        getPAP().getGraphPAP().associate(superPolicy.getSuperUserAttribute().getName(), pcUANode.getName(), new OperationSet(ALL_OPS));
-        // associate Super UA and PC OA
-        getPAP().getGraphPAP().associate(superPolicy.getSuperUserAttribute().getName(), pcOANode.getName(), new OperationSet(ALL_OPS));
-
-        // create an OA that will represent the pc
-        getPAP().getGraphPAP().createNode(rep, OA, Node.toProperties("pc", String.valueOf(name)),
-                superPolicy.getSuperObjectAttribute().getName());
-
-        return pcNode;
+        // create and return the new policy class
+        return graph.createPolicyClass(name, properties);
     }
 
     /**
@@ -106,66 +69,28 @@ public class GraphService extends Service implements Graph {
      */
     @Override
     public Node createNode(String name, NodeType type, Map<String, String> properties, String initialParent, String ... additionalParents) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        if (name == null) {
-            throw new IllegalArgumentException("a node cannot have a null name");
-        } else if (type == null) {
-            throw new IllegalArgumentException("a node cannot have a null type");
-        }
-
-        // instantiate the properties map if it's null
-        // if this node is a user, hash the password if present in the properties
-        if(properties == null) {
-            properties = new HashMap<>();
-        }
-        
-        // check that the user has the permission to assign to the parent node
-        if (!hasPermissions(userCtx, initialParent, ASSIGN_TO)) {
-            // if the user cannot assign to the parent node, delete the newly created node
-            throw new PMAuthorizationException(String.format("unauthorized permission \"%s\" on node %s", ASSIGN_TO, initialParent));
-        }
-        // if the parent is a PC get the PC default
-        Node parentNode = graph.getNode(initialParent);
-        if (parentNode.getType().equals(PC)) {
-            initialParent = getPolicyClassDefault(parentNode.getName(), type);
-            parentNode = getNode(initialParent);
-        }
-
-        // check any additional parents before assigning
-        for (int i = 0; i < additionalParents.length; i++) {
-            String parent = additionalParents[i];
-
-            if (!hasPermissions(userCtx, parent, ASSIGN_TO)) {
-                // if the user cannot assign to the parent node, delete the newly created node
-                throw new PMAuthorizationException(String.format("unauthorized permission \"%s\" on %s", ASSIGN_TO, parent));
-            }
-
-            // if the parent is a PC get the PC default
-            Node additionalParentNode = graph.getNode(parent);
-            if (additionalParentNode.getType().equals(PC)) {
-               additionalParents[i] = getPolicyClassDefault(additionalParentNode.getName(), type);
-            }
-        }
+        // check that the user can create the node in each of the parents
+        guard.checkCreateNode(userCtx, initialParent, additionalParents);
 
         //create the node
-        Node node = getGraphPAP().createNode(name, type, properties, initialParent, additionalParents);
+        Node node = graph.createNode(name, type, properties, initialParent, additionalParents);
 
+        // process the event
+        processCreateNodeEvent(node, initialParent, additionalParents);
+
+        return node;
+    }
+
+    private void processCreateNodeEvent (Node node, String initialParent, String[] additionalParents) throws PMException {
         // process event for initial parent
+        Node parentNode = graph.getNode(initialParent);
         getEPP().processEvent(new AssignToEvent(userCtx, parentNode, node));
+
         // process event for any additional parents
         for (String parent : additionalParents) {
             parentNode = graph.getNode(parent);
             getEPP().processEvent(new AssignToEvent(userCtx, parentNode, node));
         }
-
-        return node;
-    }
-
-    public String getPolicyClassDefault(String pc, NodeType type) throws PMException {
-        return pc + "_default_" + type.toString();
     }
 
     /**
@@ -178,17 +103,11 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException if the user is not authorized to update the node.
      */
     public void updateNode(String name, Map<String, String> properties) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
         // check that the user can update the node
-        if(!hasPermissions(userCtx, name, UPDATE_NODE)) {
-            throw new PMAuthorizationException(String.format("unauthorized permission %s on node %s", UPDATE_NODE, name));
-        }
+        guard.checkUpdateNode(userCtx, name);
 
         //update node in the PAP
-        getGraphPAP().updateNode(name, properties);
+        graph.updateNode(name, properties);
     }
 
     /**
@@ -200,67 +119,49 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException if the user is not authorized to delete the node.
      */
     public void deleteNode(String name) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
+        // check that the user can delete the node
+        guard.checkDeleteNode(userCtx, name);
 
-        Node node = getGraphPAP().getNode(name);
-
-        // check the user can deassign the node
-        if (!hasPermissions(userCtx, name, DEASSIGN)) {
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", name, DEASSIGN));
-        }
-
-        // check that the user can deassign from the node's parents
-        Set<String> parents = getGraphPAP().getParents(name);
-        for(String parent : parents) {
-            if(!hasPermissions(userCtx, parent, DEASSIGN_FROM)) {
-                throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", parent, DEASSIGN_FROM));
-            }
-
-            Node parentNode = getGraphPAP().getNode(parent);
-
-            getEPP().processEvent(new DeassignEvent(userCtx, node, parentNode));
-            getEPP().processEvent(new DeassignFromEvent(userCtx, parentNode, node));
-        }
+        Node node = graph.getNode(name);
 
         // if it's a PC, delete the rep
         if (node.getType().equals(PC)) {
             if (node.getProperties().containsKey(REP_PROPERTY)) {
-                getGraphPAP().deleteNode(node.getProperties().get(REP_PROPERTY));
+                graph.deleteNode(node.getProperties().get(REP_PROPERTY));
             }
         }
 
-        getGraphPAP().deleteNode(name);
+        // delete the node
+        graph.deleteNode(name);
+
+        // process the delete event
+        Set<String> parents = graph.getParents(name);
+        for(String parent : parents) {
+            Node parentNode = graph.getNode(parent);
+
+            getEPP().processEvent(new DeassignEvent(userCtx, node, parentNode));
+            getEPP().processEvent(new DeassignFromEvent(userCtx, parentNode, node));
+        }
     }
 
     /**
-     * Check that a node with the given name exists.  Just checking the in-memory graph is faster.
+     * Check that a node with the given name exists. This method will return false if the user does not have access to
+     * the node.
      * @param name the name of the node to check for.
      * @return true if a node with the given name exists, false otherwise.
      * @throws PMException if there is an error checking if the node exists in the graph through the PAP.
      */
     public boolean exists(String name) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        boolean exists = getGraphPAP().exists(name);
+        boolean exists = graph.exists(name);
         if (!exists) {
             return false;
         }
 
-        Node node = getGraphPAP().getNode(name);
+        // check that this user can access this node
+        guard.checkExists(userCtx, name);
 
-        // if the node is a pc the user must have permission on the rep OA of the PC
-        if (node.getType().equals(PC)) {
-            String pcRep = node.getProperties().get(REP_PROPERTY);
-            node = getGraphPAP().getNode(pcRep);
-            return hasPermissions(userCtx, node.getName());
-        }
-
-        // node exists, return false if the user does not have access to it.
-        return hasPermissions(userCtx, name);
+        // if the user can access this node than return true
+        return true;
     }
 
     /**
@@ -270,21 +171,8 @@ public class GraphService extends Service implements Graph {
      * @throws PMException if there is an error getting the nodes from the PAP.
      */
     public Set<Node> getNodes() throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        Set<Node> nodes = new HashSet<>(getGraphPAP().getNodes());
-        nodes.removeIf((node) -> {
-            try {
-                return !hasPermissions(userCtx, node.getName());
-            }
-            catch (PMException e) {
-                e.printStackTrace();
-                return true;
-            }
-        });
-
+        Set<Node> nodes = new HashSet<>(graph.getNodes());
+        guard.filterNodes(userCtx, nodes);
         return new HashSet<>(nodes);
     }
 
@@ -294,17 +182,13 @@ public class GraphService extends Service implements Graph {
      * @throws PMException if there is an error getting the policy classes from the PAP.
      */
     public Set<String> getPolicyClasses() throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        return getGraphPAP().getPolicyClasses();
+        return graph.getPolicyClasses();
     }
 
     /**
      * Get the children of the node from the graph.  Get the children from the database to ensure all node information
      * is present.  Before returning the set of nodes, filter out any nodes that the user has no permissions on.
-     * 
+     *
      * @param name the name of the node to get the children of.
      * @return a set of Node objects, representing the children of the target node.
      * @throws PMException if the target node does not exist.
@@ -312,56 +196,30 @@ public class GraphService extends Service implements Graph {
 
      */
     public Set<String> getChildren(String name) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
         if(!exists(name)) {
             throw new PMException(String.format("node %s could not be found", name));
         }
 
-        Set<String> children = getGraphPAP().getChildren(name);
-        children.removeIf((node) -> {
-            try {
-                return !hasPermissions(userCtx, node);
-            }
-            catch (PMException e) {
-                e.printStackTrace();
-                return true;
-            }
-        });
-
+        Set<String> children = graph.getChildren(name);
+        guard.filter(userCtx, children);
         return children;
     }
 
     /**
-     * Get the parents of the node from the graph.  Get the parents from the database to ensure all node information
-     * is present.  Before returning the set of nodes, filter out any nodes that the user has no permissions on.
+     * Get the parents of the node from the graph.  Before returning the set of nodes, filter out any nodes that the user
+     * has no permissions on.
      * @param name the name of the node to get the parents of.
      * @return a set of Node objects, representing the parents of the target node.
      * @throws PMException if the target node does not exist.
      * @throws PMException if there is an error getting the parents from the PAP.
      */
     public Set<String> getParents(String name) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
         if(!exists(name)) {
             throw new PMException(String.format("node %s could not be found", name));
         }
 
-        Set<String> parents = getGraphPAP().getParents(name);
-        parents.removeIf((node) -> {
-            try {
-                return !hasPermissions(userCtx, node);
-            }
-            catch (PMException e) {
-                e.printStackTrace();
-                return true;
-            }
-        });
-
+        Set<String> parents = graph.getParents(name);
+        guard.filter(userCtx, parents);
         return parents;
     }
 
@@ -377,43 +235,15 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException if the current user does not have permission to create the assignment.
      */
     public void assign(String child, String parent) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        // check that the nodes are not null
-        if(child == null) {
-            throw new IllegalArgumentException("the child node name cannot be null when creating an assignment");
-        } else if(parent == null) {
-            throw new IllegalArgumentException("the parent node name cannot be null when creating an assignment");
-        } else if(!exists(child)) {
-            throw new PMException(String.format("child node %s does not exist", child));
-        } else if(!exists(parent)) {
-            throw new PMException(String.format("parent node %s does not exist", parent));
-        }
-
-        //check the user can assign the child
-        if(!hasPermissions(userCtx, child, ASSIGN)) {
-            throw new PMAuthorizationException(String.format("unauthorized permission %s on node %s", ASSIGN, child));
-        }
-
-        //check if the assignment is valid
-        Node childNode = getNode(child);
-        Node parentNode = getNode(parent);
-        Assignment.checkAssignment(childNode.getType(), parentNode.getType());
-
-        // check that the user can assign to the parent node
-        if (!hasPermissions(userCtx, parent, ASSIGN_TO)) {
-            throw new PMAuthorizationException(String.format("unauthorized permission %s on node %s", ASSIGN_TO, parent));
-        }
-
-        if (parentNode.getType().equals(PC)) {
-            parent = getPolicyClassDefault(parentNode.getName(), childNode.getType());
-        }
+        // check that the user can make the assignment
+        guard.checkAssign(userCtx, child, parent);
 
         // assign in the PAP
-        getGraphPAP().assign(child, parent);
+        graph.assign(child, parent);
 
+        // process the assignment as to events - assign and assign to
+        Node childNode = getNode(child);
+        Node parentNode = getNode(parent);
         getEPP().processEvent(new AssignEvent(userCtx, childNode, parentNode));
         getEPP().processEvent(new AssignToEvent(userCtx, parentNode, childNode));
     }
@@ -429,51 +259,25 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException if the current user does not have permission to delete the assignment.
      */
     public void deassign(String child, String parent) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        // check that the parameters are correct
-        if(child == null) {
-            throw new IllegalArgumentException("the child node cannot be null when deassigning");
-        } else if(parent == null) {
-            throw new IllegalArgumentException("the parent node cannot be null when deassigning");
-        } else if(!exists(child)) {
-            throw new PMException(String.format("child node %s could not be found when deassigning", child));
-        } else if(!exists(parent)) {
-            throw new PMException(String.format("parent node %s could not be found when deassigning", parent));
-        }
-
-        //check the user can deassign the child
-        if(!hasPermissions(userCtx, child, DEASSIGN)) {
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", child, DEASSIGN));
-        }
-
-        //check that the user can deassign from the parent
-        if (!hasPermissions(userCtx, parent, DEASSIGN_FROM)) {
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", parent, DEASSIGN_FROM));
-        }
+        // check the user can delete the assignment
+        guard.checkDeassign(userCtx, child, parent);
 
         //delete assignment in PAP
-        getGraphPAP().deassign(child, parent);
+        graph.deassign(child, parent);
 
+        // process the deassign as two events - deassign and deassign from
         Node parentNode = getNode(parent);
         Node childNode = getNode(child);
-
         getEPP().processEvent(new DeassignEvent(userCtx, childNode, parentNode));
         getEPP().processEvent(new DeassignFromEvent(userCtx, parentNode, childNode));
     }
 
     @Override
     public boolean isAssigned(String child, String parent) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
         Node parentNode = getNode(parent);
         Node childNode = getNode(child);
 
-        return getGraphPAP().isAssigned(childNode.getName(), parentNode.getName());
+        return graph.isAssigned(childNode.getName(), parentNode.getName());
 
     }
 
@@ -493,31 +297,11 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException if the current user does not have permission to create the association.
      */
     public void associate(String ua, String target, OperationSet operations) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        if(ua == null) {
-            throw new IllegalArgumentException("the user attribute cannot be null when creating an association");
-        } else if(target == null) {
-            throw new IllegalArgumentException("the target node cannot be null when creating an association");
-        }
-
-        Node sourceNode = getNode(ua);
-        Node targetNode = getNode(target);
-
-        Association.checkAssociation(sourceNode.getType(), targetNode.getType());
-
-        //check the user can associate the source and target nodes
-        if(!hasPermissions(userCtx, ua, ASSOCIATE)) {
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", sourceNode.getName(), ASSOCIATE));
-        }
-        if (!hasPermissions(userCtx, target, ASSOCIATE)) {
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", targetNode.getName(), ASSOCIATE));
-        }
+        // check that this user can create the association
+        guard.checkAssociate(userCtx, ua, target);
 
         //create association in PAP
-        getGraphPAP().associate(ua, target, operations);
+        graph.associate(ua, target, operations);
     }
 
     /**
@@ -533,30 +317,11 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException If the current user does not have permission to delete the association.
      */
     public void dissociate(String ua, String target) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        if(ua == null) {
-            throw new IllegalArgumentException("the user attribute cannot be null when creating an association");
-        } else if(target == null) {
-            throw new IllegalArgumentException("the target cannot be null when creating an association");
-        } else if(!exists(ua)) {
-            throw new PMException(String.format("node %s could not be found when creating an association", ua));
-        } else if(!exists(target)) {
-            throw new PMException(String.format("node %s could not be found when creating an association", target));
-        }
-
-        //check the user can associate the source and target nodes
-        if(!hasPermissions(userCtx, ua, DISASSOCIATE)) {
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", ua, DISASSOCIATE));
-        }
-        if (!hasPermissions(userCtx, target, DISASSOCIATE)) {
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", target, DISASSOCIATE));
-        }
+        // check that the user can delete the association
+        guard.checkDissociate(userCtx, ua, target);
 
         //create association in PAP
-        getGraphPAP().dissociate(ua, target);
+        graph.dissociate(ua, target);
     }
 
     /**
@@ -569,20 +334,16 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException If the current user does not have permission to get hte node's associations.
      */
     public Map<String, OperationSet> getSourceAssociations(String source) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
+        // check that this user can get the associations of the source node
+        guard.checkGetAssociations(userCtx, source);
 
-        if(!exists(source)) {
-            throw new PMException(String.format("node %s could not be found", source));
-        }
+        // get the associations for the source node
+        Map<String, OperationSet> sourceAssociations = graph.getSourceAssociations(source);
 
-        //check the user can get the associations of the source node
-        if(!hasPermissions(userCtx, source, GET_ASSOCIATIONS)){
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", source, GET_ASSOCIATIONS));
-        }
+        // filter out any associations in which the user does not have access to the target attribute
+        guard.filter(userCtx, sourceAssociations);
 
-        return getGraphPAP().getSourceAssociations(source);
+        return sourceAssociations;
     }
 
     /**
@@ -595,30 +356,32 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException If the current user does not have permission to get hte node's associations.
      */
     public Map<String, OperationSet> getTargetAssociations(String target) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
+        // check that this user can get the associations of the target node
+        guard.checkGetAssociations(userCtx, target);
 
-        if(!exists(target)) {
-            throw new PMException(String.format("node %s could not be found", target));
-        }
+        // get the associations for the target node
+        Map<String, OperationSet> targetAssociations = graph.getTargetAssociations(target);
 
-        //check the user can get the associations of the source node
-        if(!hasPermissions(userCtx, target, GET_ASSOCIATIONS)){
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", target, GET_ASSOCIATIONS));
-        }
+        // filter out any associations in which the user does not have access to the source attribute
+        guard.filter(userCtx, targetAssociations);
 
-        return getGraphPAP().getTargetAssociations(target);
+        return targetAssociations;
     }
 
     @Override
     public String toJson() throws PMException {
-        return getGraphPAP().toJson();
+        // check that the user can serialize to json
+        guard.checkToJson(userCtx);
+
+        return graph.toJson();
     }
 
     @Override
     public void fromJson(String s) throws PMException {
-        getGraphPAP().fromJson(s);
+        // check that the user can deserialize a json string to the graph
+        guard.checkFromJson(userCtx);
+
+        graph.fromJson(s);
     }
 
     /**
@@ -633,19 +396,8 @@ public class GraphService extends Service implements Graph {
      */
     @Override
     public Set<Node> search(NodeType type, Map<String, String> properties) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
-
-        Set<Node> search = getGraphPAP().search(type, properties);
-        search.removeIf(x -> {
-            try {
-                return !hasPermissions(userCtx, x.getName());
-            }
-            catch (PMException e) {
-                return true;
-            }
-        });
+        Set<Node> search = graph.search(type, properties);
+        guard.filterNodes(userCtx, search);
         return search;
     }
 
@@ -658,27 +410,32 @@ public class GraphService extends Service implements Graph {
      * @throws PMAuthorizationException if the current user is not authorized to access this node.
      */
     public Node getNode(String name) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
+        // get node
+        Node node = graph.getNode(name);
 
-        if(!exists(name)) {
+        // check user has permissions on the node
+        try {
+            guard.checkExists(userCtx, name);
+        } catch (PMException e) {
+            // if no permissions, the user shouldn't know it exists
             throw new PMException(String.format("node %s could not be found", name));
         }
 
-        if(!hasPermissions(userCtx, name)) {
-            throw new PMAuthorizationException(String.format("no permissions on %s: %s", name));
-        }
-
-        return getGraphPAP().getNode(name);
+        return node;
     }
 
     @Override
     public Node getNode(NodeType type, Map<String, String> properties) throws PMException {
-        Node node = getGraphPAP().getNode(type, properties);
-        if (!hasPermissions(userCtx, node.getName())) {
+        Node node = graph.getNode(type, properties);
+
+        // check user has permissions on the node
+        try {
+            guard.checkExists(userCtx, node.getName());
+        } catch (PMException e) {
+            // if no permissions, the user shouldn't know it exists
             throw new PMException(String.format("node (%s, %s) could not be found", type, properties.toString()));
         }
+
         return node;
     }
 
@@ -688,22 +445,15 @@ public class GraphService extends Service implements Graph {
      * @throws PMException if something goes wrong in the deletion process
      */
     public void reset(UserContext userCtx) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
+        guard.checkReset(userCtx);
 
-        // check that the user can reset the graph
-        if (!hasPermissions(userCtx, superPolicy.getSuperPolicyClassRep().getName(), RESET)) {
-            throw new PMAuthorizationException("unauthorized permissions to reset the graph");
-        }
-
-        Collection<Node> nodes = getGraphPAP().getNodes();
+        Collection<Node> nodes = graph.getNodes();
         Set<String> names = new HashSet<>();
         for (Node node: nodes) {
             names.add(node.getName());
         }
         for (String name : names) {
-            getGraphPAP().deleteNode(name);
+            graph.deleteNode(name);
         }
     }
 }

--- a/src/main/java/gov/nist/csd/pm/pdp/services/ObligationsService.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/ObligationsService.java
@@ -28,36 +28,50 @@ public class ObligationsService extends Service implements Obligations {
 
     @Override
     public void add(Obligation obligation, boolean enable) throws PMException {
+        guard.checkAdd(userCtx);
+
         getObligationsAdmin().add(obligation, enable);
     }
 
     @Override
-    public Obligation get(String label) {
+    public Obligation get(String label) throws PMException {
+        guard.checkGet(userCtx);
+
         return getObligationsAdmin().get(label);
     }
 
     @Override
-    public List<Obligation> getAll() {
+    public List<Obligation> getAll() throws PMException {
+        guard.checkGet(userCtx);
+
         return getObligationsAdmin().getAll();
     }
 
     @Override
-    public void update(String label, Obligation obligation) {
+    public void update(String label, Obligation obligation) throws PMException {
+        guard.checkUpdate(userCtx);
+
         getObligationsAdmin().update(label, obligation);
     }
 
     @Override
-    public void delete(String label) {
+    public void delete(String label) throws PMException {
+        guard.checkDelete(userCtx);
+
         getObligationsAdmin().delete(label);
     }
 
     @Override
-    public void setEnable(String label, boolean enabled) {
+    public void setEnable(String label, boolean enabled) throws PMException {
+        guard.checkEnable(userCtx);
+
         getObligationsAdmin().setEnable(label, enabled);
     }
 
     @Override
-    public List<Obligation> getEnabled() {
+    public List<Obligation> getEnabled() throws PMException {
+        guard.checkGet(userCtx);
+
         return getObligationsAdmin().getEnabled();
     }
 

--- a/src/main/java/gov/nist/csd/pm/pdp/services/ProhibitionsService.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/ProhibitionsService.java
@@ -1,15 +1,13 @@
 package gov.nist.csd.pm.pdp.services;
 
 import gov.nist.csd.pm.operations.OperationSet;
-import gov.nist.csd.pm.operations.Operations;
 import gov.nist.csd.pm.epp.EPP;
 import gov.nist.csd.pm.exceptions.PMAuthorizationException;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.pap.PAP;
-import gov.nist.csd.pm.pdp.decider.Decider;
-import gov.nist.csd.pm.pdp.policy.SuperPolicy;
+import gov.nist.csd.pm.pap.policies.SuperPolicy;
+import gov.nist.csd.pm.pdp.services.guard.ProhibitionsGuard;
 import gov.nist.csd.pm.pip.prohibitions.Prohibitions;
-import gov.nist.csd.pm.pip.prohibitions.model.ContainerCondition;
 import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
 
 import java.util.*;
@@ -18,80 +16,63 @@ import static gov.nist.csd.pm.operations.Operations.*;
 
 public class ProhibitionsService extends Service implements Prohibitions {
 
-    public ProhibitionsService(PAP pap, EPP epp, OperationSet resourceOps, SuperPolicy superPolicy) {
+    private ProhibitionsGuard guard;
+
+    public ProhibitionsService(PAP pap, EPP epp, OperationSet resourceOps) {
         super(pap, epp, resourceOps);
 
-        this.superPolicy = superPolicy;
-    }
-
-    public List<Prohibition> getProhibitions() throws PMException {
-        return getProhibitionsPAP().getAll();
+        this.guard = new ProhibitionsGuard(pap, resourceOps);
     }
 
     @Override
     public void add(Prohibition prohibition) throws PMException {
-        String name = prohibition.getName();
-
-        //check that the prohibition name is not null or empty
-        if(name == null || name.isEmpty()) {
-            throw new IllegalArgumentException("a null name was provided when creating a prohibition");
-        }
-
-        //check the prohibitions doesn't already exist
-        for(Prohibition p : getProhibitions()) {
-            if(p.getName().equals(name)) {
-                throw new PMException(String.format("a prohibition with the name %s already exists", name));
-            }
-        }
-
-        // check that the user has permission to create a prohibition on the super policy object
-        if(!getDecider().check(userCtx.getUser(), userCtx.getProcess(), superPolicy.getSuperObjectAttribute().getName(), CREATE_PROHIBITION)) {
-            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", superPolicy.getSuperObjectAttribute().getName(), CREATE_PROHIBITION));
-        }
+        guard.checkAdd(userCtx, prohibition);
 
         //create prohibition in PAP
-        getProhibitionsPAP().add(prohibition);
+        getProhibitionsAdmin().add(prohibition);
     }
 
     @Override
     public List<Prohibition> getAll() throws PMException {
-        return getProhibitionsPAP().getAll();
+        List<Prohibition> all = getProhibitionsAdmin().getAll();
+        guard.filter(userCtx, all);
+        return all;
     }
 
     @Override
     public Prohibition get(String prohibitionName) throws PMException {
-        return getPAP().getProhibitionsPAP().get(prohibitionName);
+        Prohibition prohibition = getProhibitionsAdmin().get(prohibitionName);
+        guard.checkGet(userCtx, prohibition);
+
+        return prohibition;
     }
 
     @Override
     public List<Prohibition> getProhibitionsFor(String subject) throws PMException {
-        return getPAP().getProhibitionsPAP().getProhibitionsFor(subject);
+        List<Prohibition> prohibitionsFor = getProhibitionsAdmin().getProhibitionsFor(subject);
+        guard.filter(userCtx, prohibitionsFor);
+        return prohibitionsFor;
     }
 
     @Override
     public void update(String prohibitionName, Prohibition prohibition) throws PMException {
-        getPAP().getProhibitionsPAP().update(prohibitionName, prohibition);
+        guard.checkUpdate(userCtx, prohibition);
+        getProhibitionsAdmin().update(prohibitionName, prohibition);
     }
 
     @Override
     public void delete(String prohibitionName) throws PMException {
-        getPAP().getProhibitionsPAP().delete(prohibitionName);
+        guard.checkDelete(userCtx, getProhibitionsAdmin().get(prohibitionName));
+        getProhibitionsAdmin().delete(prohibitionName);
     }
 
     public void reset(UserContext userCtx) throws PMException {
-        if(userCtx == null) {
-            throw new PMException("no user context provided to the PDP");
-        }
+        guard.checkReset(userCtx);
 
-        // check that the user can reset the graph
-        if (!hasPermissions(userCtx, superPolicy.getSuperPolicyClassRep().getName(), RESET)) {
-            throw new PMAuthorizationException("unauthorized permissions to reset the graph");
-        }
-
-        List<Prohibition> prohibitions = getProhibitions();
+        List<Prohibition> prohibitions = getProhibitionsAdmin().getAll();
         Set<String> names = new HashSet<>();
-        for (Prohibition prohib : prohibitions) {
-            names.add(prohib.getName());
+        for (Prohibition pro : prohibitions) {
+            names.add(pro.getName());
         }
         for (String name : names) {
             delete(name);

--- a/src/main/java/gov/nist/csd/pm/pdp/services/Service.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/Service.java
@@ -1,22 +1,14 @@
 package gov.nist.csd.pm.pdp.services;
 
 import gov.nist.csd.pm.epp.EPP;
-import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
 import gov.nist.csd.pm.pap.PAP;
 import gov.nist.csd.pm.pdp.decider.Decider;
 import gov.nist.csd.pm.pdp.decider.PReviewDecider;
-import gov.nist.csd.pm.pdp.policy.SuperPolicy;
+import gov.nist.csd.pm.pap.policies.SuperPolicy;
 import gov.nist.csd.pm.pip.graph.Graph;
-import gov.nist.csd.pm.pip.graph.model.nodes.Node;
 import gov.nist.csd.pm.pip.obligations.Obligations;
 import gov.nist.csd.pm.pip.prohibitions.Prohibitions;
-
-import java.util.Arrays;
-import java.util.Set;
-
-import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.PC;
-import static gov.nist.csd.pm.pip.graph.model.nodes.Properties.REP_PROPERTY;
 
 /**
  * Class to provide common methods to all services.
@@ -58,16 +50,16 @@ public class Service {
         return this.pap;
     }
 
-    Graph getGraphPAP() {
-        return pap.getGraphPAP();
+    Graph getGraphAdmin() {
+        return pap.getGraphAdmin();
     }
 
-    Prohibitions getProhibitionsPAP() {
-        return pap.getProhibitionsPAP();
+    Prohibitions getProhibitionsAdmin() {
+        return pap.getProhibitionsAdmin();
     }
 
-    Obligations getObligationsPAP() {
-        return pap.getObligationsPAP();
+    Obligations getObligationsAdmin() {
+        return pap.getObligationsAdmin();
     }
 
     public OperationSet getResourceOps() {
@@ -79,26 +71,6 @@ public class Service {
     }
 
     public Decider getDecider() {
-        return new PReviewDecider(getGraphPAP(), getProhibitionsPAP(), resourceOps);
-    }
-
-    boolean hasPermissions(UserContext userCtx, String target, String... permissions) throws PMException {
-        Decider decider = new PReviewDecider(pap.getGraphPAP(), pap.getProhibitionsPAP(), resourceOps);
-
-        Node node = pap.getGraphPAP().getNode(target);
-        if (node.getType().equals(PC)) {
-            if (!node.getProperties().containsKey(REP_PROPERTY)) {
-                throw new PMException("unable to check permissions for policy class " + node.getName() + ", rep property not set");
-            }
-
-            target = node.getProperties().get(REP_PROPERTY);
-        }
-
-        Set<String> allowed = decider.list(userCtx.getUser(), userCtx.getProcess(), target);
-        if(permissions.length == 0) {
-            return !allowed.isEmpty();
-        } else {
-            return  allowed.containsAll(Arrays.asList(permissions));
-        }
+        return new PReviewDecider(getGraphAdmin(), getProhibitionsAdmin(), resourceOps);
     }
 }

--- a/src/main/java/gov/nist/csd/pm/pdp/services/guard/GraphGuard.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/guard/GraphGuard.java
@@ -1,0 +1,171 @@
+package gov.nist.csd.pm.pdp.services.guard;
+
+import gov.nist.csd.pm.exceptions.PMAuthorizationException;
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pdp.services.UserContext;
+import gov.nist.csd.pm.pip.graph.model.nodes.Node;
+
+import java.util.Map;
+import java.util.Set;
+
+import static gov.nist.csd.pm.operations.Operations.*;
+import static gov.nist.csd.pm.operations.Operations.UPDATE_NODE;
+import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.PC;
+import static gov.nist.csd.pm.pip.graph.model.nodes.Properties.REP_PROPERTY;
+
+public class GraphGuard extends Guard {
+
+    public GraphGuard(PAP pap, OperationSet resourceOps) {
+        super(pap, resourceOps);
+    }
+
+    public void checkCreatePolicyClass(UserContext userCtx) throws PMException {
+        // check that the user can create a policy class
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperPolicyClassRep().getName(), CREATE_POLICY_CLASS)) {
+            throw new PMAuthorizationException("unauthorized permissions to create a policy class");
+        }
+    }
+
+    public void checkCreateNode(UserContext userCtx, String initialParent, String[] additionalParents) throws PMException {
+        // check that the user has the permission to assign to the parent node
+        if (!hasPermissions(userCtx, initialParent, ASSIGN_TO)) {
+            // if the user cannot assign to the parent node, delete the newly created node
+            throw new PMAuthorizationException(String.format("unauthorized permission \"%s\" on node %s", ASSIGN_TO, initialParent));
+        }
+
+        // check any additional parents before assigning
+        for (String parent : additionalParents) {
+            if (!hasPermissions(userCtx, parent, ASSIGN_TO)) {
+                // if the user cannot assign to the parent node, delete the newly created node
+                throw new PMAuthorizationException(String.format("unauthorized permission \"%s\" on %s", ASSIGN_TO, parent));
+            }
+        }
+    }
+
+    public void checkUpdateNode(UserContext userCtx, String name) throws PMException {
+        // check that the user can update the node
+        if(!hasPermissions(userCtx, name, UPDATE_NODE)) {
+            throw new PMAuthorizationException(String.format("unauthorized permission %s on node %s", UPDATE_NODE, name));
+        }
+    }
+
+    public void checkDeleteNode(UserContext userCtx, String node) throws PMException {
+        // check the user can deassign the node
+        if (!hasPermissions(userCtx, node, DEASSIGN)) {
+            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", node, DEASSIGN));
+        }
+
+        // check that the user can deassign from the node's parents
+        Set<String> parents = pap.getGraphAdmin().getParents(node);
+        for(String parent : parents) {
+            if(!hasPermissions(userCtx, parent, DEASSIGN_FROM)) {
+                throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", parent, DEASSIGN_FROM));
+            }
+        }
+    }
+
+    public void checkExists(UserContext userCtx, String name) throws PMException {
+        // a user only needs one permission to know a node exists
+        // however receiving an unauthorized exception would let the user know it exists
+        // therefore, a general PMException is thrown indicating that the node may not exist or
+        // the user may not have permissions
+        if(!hasPermissions(userCtx, name)) {
+            throw new PMException(name + " does not exist or " + userCtx + " is not authorized");
+        }
+    }
+
+    public void filter(UserContext userCtx, Set<String> nodes) throws PMException {
+        nodes.removeIf(node -> {
+            try {
+                return !hasPermissions(userCtx, node);
+            } catch (PMException e) {
+                return true;
+            }
+        });
+    }
+
+    public void filterNodes(UserContext userCtx, Set<Node> nodes) {
+        nodes.removeIf(node -> {
+            try {
+                return !hasPermissions(userCtx, node.getName());
+            } catch (PMException e) {
+                return true;
+            }
+        });
+    }
+
+    public void filter(UserContext userCtx, Map<String, OperationSet> map) {
+        map.keySet().removeIf(key -> {
+            try {
+                return !hasPermissions(userCtx, key);
+            } catch (PMException e) {
+                return true;
+            }
+        });
+    }
+
+    public void checkAssign(UserContext userCtx, String child, String parent) throws PMException {
+        //check the user can assign the child
+        if(!hasPermissions(userCtx, child, ASSIGN)) {
+            throw new PMAuthorizationException(String.format("unauthorized permission %s on node %s", ASSIGN, child));
+        }
+
+        // check that the user can assign to the parent node
+        if (!hasPermissions(userCtx, parent, ASSIGN_TO)) {
+            throw new PMAuthorizationException(String.format("unauthorized permission %s on node %s", ASSIGN_TO, parent));
+        }
+    }
+
+    public void checkDeassign(UserContext userCtx, String child, String parent) throws PMException {
+        //check the user can deassign the child
+        if(!hasPermissions(userCtx, child, DEASSIGN)) {
+            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", child, DEASSIGN));
+        }
+
+        //check that the user can deassign from the parent
+        if (!hasPermissions(userCtx, parent, DEASSIGN_FROM)) {
+            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", parent, DEASSIGN_FROM));
+        }
+    }
+
+    public void checkAssociate(UserContext userCtx, String ua, String target) throws PMException {
+        //check the user can associate the source and target nodes
+        if(!hasPermissions(userCtx, ua, ASSOCIATE)) {
+            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", ua, ASSOCIATE));
+        }
+        if (!hasPermissions(userCtx, target, ASSOCIATE)) {
+            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", target, ASSOCIATE));
+        }
+    }
+
+    public void checkDissociate(UserContext userCtx, String ua, String target) throws PMException {
+        //check the user can associate the source and target nodes
+        if(!hasPermissions(userCtx, ua, DISASSOCIATE)) {
+            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", ua, DISASSOCIATE));
+        }
+        if (!hasPermissions(userCtx, target, DISASSOCIATE)) {
+            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", target, DISASSOCIATE));
+        }
+    }
+
+    public void checkGetAssociations(UserContext userCtx, String node) throws PMException {
+        //check the user can get the associations of the source node
+        if(!hasPermissions(userCtx, node, GET_ASSOCIATIONS)){
+            throw new PMAuthorizationException(String.format("unauthorized permissions on %s: %s", node, GET_ASSOCIATIONS));
+        }
+    }
+
+    public void checkToJson(UserContext userCtx) throws PMException {
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperPolicyClassRep().getName(), TO_JSON)) {
+            throw new PMAuthorizationException("unauthorized permissions to serialize graph to json");
+        }
+    }
+
+    public void checkFromJson(UserContext userCtx) throws PMException {
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperPolicyClassRep().getName(), FROM_JSON)) {
+            throw new PMAuthorizationException("unauthorized permissions to deserialize json to graph");
+        }
+    }
+}

--- a/src/main/java/gov/nist/csd/pm/pdp/services/guard/Guard.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/guard/Guard.java
@@ -1,0 +1,67 @@
+package gov.nist.csd.pm.pdp.services.guard;
+
+import gov.nist.csd.pm.exceptions.PMAuthorizationException;
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pdp.decider.Decider;
+import gov.nist.csd.pm.pdp.decider.PReviewDecider;
+import gov.nist.csd.pm.pdp.services.UserContext;
+import gov.nist.csd.pm.pip.graph.model.nodes.Node;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static gov.nist.csd.pm.operations.Operations.RESET;
+import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.PC;
+import static gov.nist.csd.pm.pip.graph.model.nodes.Properties.REP_PROPERTY;
+
+public class Guard {
+
+    protected PAP pap;
+    protected Decider decider;
+    private OperationSet resourceOps;
+
+    public Guard(PAP pap, OperationSet resourceOps) {
+        this.pap = pap;
+        this.resourceOps = resourceOps;
+        this.decider = new PReviewDecider(pap.getGraphAdmin(), pap.getProhibitionsAdmin(), resourceOps);
+    }
+
+    private void assertUserCtx(UserContext userCtx) throws PMException {
+        if(userCtx == null) {
+            throw new PMException("no user context provided to the PDP");
+        }
+    }
+
+    boolean hasPermissions(UserContext userCtx, String target, String... permissions) throws PMException {
+        // assert that the user context is not null
+        assertUserCtx(userCtx);
+
+        // if checking the permissions on a PC, check the permissions on the rep node for the PC
+        Node node = pap.getGraphAdmin().getNode(target);
+        if (node.getType().equals(PC)) {
+            if (!node.getProperties().containsKey(REP_PROPERTY)) {
+                throw new PMException("unable to check permissions for policy class " + node.getName() + ", rep property not set");
+            }
+
+            target = node.getProperties().get(REP_PROPERTY);
+        }
+
+        // check for permissions
+        Set<String> allowed = decider.list(userCtx.getUser(), userCtx.getProcess(), target);
+        if(permissions.length == 0) {
+            return !allowed.isEmpty();
+        } else {
+            return  allowed.containsAll(Arrays.asList(permissions));
+        }
+    }
+
+    public void checkReset(UserContext userCtx) throws PMException {
+        // check that the user can reset the graph
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperPolicyClassRep().getName(), RESET)) {
+            throw new PMAuthorizationException("unauthorized permissions to reset the prohibitions");
+        }
+    }
+
+}

--- a/src/main/java/gov/nist/csd/pm/pdp/services/guard/ObligationsGuard.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/guard/ObligationsGuard.java
@@ -1,7 +1,12 @@
 package gov.nist.csd.pm.pdp.services.guard;
 
+import gov.nist.csd.pm.exceptions.PMAuthorizationException;
+import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
 import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pdp.services.UserContext;
+
+import static gov.nist.csd.pm.operations.Operations.*;
 
 public class ObligationsGuard extends Guard {
 
@@ -9,4 +14,38 @@ public class ObligationsGuard extends Guard {
         super(pap, resourceOps);
     }
 
+    public void checkAdd(UserContext userCtx) throws PMException {
+        // check that the user can create a policy class
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperObjectAttribute().getName(), ADD_OBLIGATION)) {
+            throw new PMAuthorizationException("unauthorized permissions to create a policy class");
+        }
+    }
+
+    public void checkGet(UserContext userCtx) throws PMException {
+        // check that the user can create a policy class
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperObjectAttribute().getName(), GET_OBLIGATION)) {
+            throw new PMAuthorizationException("unauthorized permissions to create a policy class");
+        }
+    }
+
+    public void checkUpdate(UserContext userCtx) throws PMException {
+        // check that the user can create a policy class
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperObjectAttribute().getName(), UPDATE_OBLIGATION)) {
+            throw new PMAuthorizationException("unauthorized permissions to create a policy class");
+        }
+    }
+
+    public void checkDelete(UserContext userCtx) throws PMException {
+        // check that the user can create a policy class
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperObjectAttribute().getName(), DELETE_OBLIGATION)) {
+            throw new PMAuthorizationException("unauthorized permissions to create a policy class");
+        }
+    }
+
+    public void checkEnable(UserContext userCtx) throws PMException {
+        // check that the user can create a policy class
+        if (!hasPermissions(userCtx, pap.getGraphAdmin().getSuperPolicy().getSuperObjectAttribute().getName(), ENABLE_OBLIGATION)) {
+            throw new PMAuthorizationException("unauthorized permissions to create a policy class");
+        }
+    }
 }

--- a/src/main/java/gov/nist/csd/pm/pdp/services/guard/ObligationsGuard.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/guard/ObligationsGuard.java
@@ -1,0 +1,12 @@
+package gov.nist.csd.pm.pdp.services.guard;
+
+import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.PAP;
+
+public class ObligationsGuard extends Guard {
+
+    public ObligationsGuard(PAP pap, OperationSet resourceOps) {
+        super(pap, resourceOps);
+    }
+
+}

--- a/src/main/java/gov/nist/csd/pm/pdp/services/guard/ProhibitionsGuard.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/guard/ProhibitionsGuard.java
@@ -1,0 +1,67 @@
+package gov.nist.csd.pm.pdp.services.guard;
+
+import gov.nist.csd.pm.exceptions.PMAuthorizationException;
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pdp.services.UserContext;
+import gov.nist.csd.pm.pip.prohibitions.model.ContainerCondition;
+import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
+
+import java.util.List;
+import java.util.Map;
+
+import static gov.nist.csd.pm.operations.Operations.*;
+
+public class ProhibitionsGuard extends Guard {
+
+    public ProhibitionsGuard(PAP pap, OperationSet resourceOps) {
+        super(pap, resourceOps);
+    }
+
+    private void check(UserContext userCtx, Prohibition prohibition, String permission) throws PMException {
+        String subject = prohibition.getSubject();
+        Map<String, Boolean> containers = prohibition.getContainers();
+
+        // check prohibition subject
+        if (pap.getGraphAdmin().exists(subject)) {
+            if (!hasPermissions(userCtx, subject, permission)) {
+                throw new PMAuthorizationException(String.format("unauthorized permission %s on %s", permission, subject));
+            }
+        }
+
+        // check each container in prohibition
+        for (String container : containers.keySet()) {
+            if (!hasPermissions(userCtx, container, permission)) {
+                throw new PMAuthorizationException(String.format("unauthorized permission %s on %s", permission, container));
+            }
+        }
+    }
+
+    public void checkAdd(UserContext userCtx, Prohibition prohibition) throws PMException {
+        check(userCtx, prohibition, CREATE_PROHIBITION);
+    }
+
+    public void checkGet(UserContext userCtx, Prohibition prohibition) throws PMException {
+        check(userCtx, prohibition, VIEW_PROHIBITION);
+    }
+
+    public void checkUpdate(UserContext userCtx, Prohibition prohibition) throws PMException {
+        check(userCtx, prohibition, UPDATE_PROHIBITION);
+    }
+
+    public void checkDelete(UserContext userCtx, Prohibition prohibition) throws PMException {
+        check(userCtx, prohibition, DELETE_PROHIBITION);
+    }
+
+    public void filter(UserContext userCtx, List<Prohibition> prohibitions) {
+        prohibitions.removeIf(prohibition -> {
+            try {
+                checkGet(userCtx, prohibition);
+                return false;
+            } catch (PMException e) {
+                return true;
+            }
+        });
+    }
+}

--- a/src/main/java/gov/nist/csd/pm/pip/obligations/Obligations.java
+++ b/src/main/java/gov/nist/csd/pm/pip/obligations/Obligations.java
@@ -8,16 +8,16 @@ import java.util.List;
 public interface Obligations {
     void add(Obligation obligation, boolean enable) throws PMException;
 
-    Obligation get(String label);
+    Obligation get(String label) throws PMException;
 
-    List<Obligation> getAll();
+    List<Obligation> getAll() throws PMException;
 
-    void update(String label, Obligation obligation);
+    void update(String label, Obligation obligation) throws PMException;
 
-    void delete(String label);
+    void delete(String label) throws PMException;
 
-    void setEnable(String label, boolean enabled);
+    void setEnable(String label, boolean enabled) throws PMException;
 
-    List<Obligation> getEnabled();
+    List<Obligation> getEnabled() throws PMException;
 
 }

--- a/src/test/java/gov/nist/csd/pm/epp/EPPTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/EPPTest.java
@@ -5,7 +5,10 @@ import gov.nist.csd.pm.epp.events.AssignToEvent;
 import gov.nist.csd.pm.epp.events.DeassignEvent;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.GraphAdmin;
+import gov.nist.csd.pm.pap.ObligationsAdmin;
 import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pap.ProhibitionsAdmin;
 import gov.nist.csd.pm.pdp.PDP;
 import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.Graph;
@@ -38,7 +41,13 @@ class EPPTest {
 
     @BeforeEach
     void setup() throws PMException {
-        pdp = PDP.newPDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), new EPPOptions(), new OperationSet("read", "write", "execute"));
+        pdp = PDP.newPDP(
+                new PAP(
+                        new GraphAdmin(new MemGraph()),
+                        new ProhibitionsAdmin(new MemProhibitions()),
+                        new ObligationsAdmin(new MemObligations())),
+                new EPPOptions(),
+                new OperationSet("read", "write", "execute"));
         Graph graph = pdp.getGraphService(new UserContext("super"));
         pc1 = graph.createPolicyClass("pc1", null);
         oa1 = graph.createNode("oa1", NodeType.OA, null, pc1.getName());
@@ -131,7 +140,10 @@ class EPPTest {
         Obligations obligations = new MemObligations();
         obligations.add(obligation, true);
 
-        PDP pdp = PDP.newPDP(new PAP(graph, new MemProhibitions(), obligations), new EPPOptions(), new OperationSet("read", "write", "execute"));
+        PDP pdp = PDP.newPDP(
+                new PAP(new GraphAdmin(graph), new ProhibitionsAdmin(new MemProhibitions()), new ObligationsAdmin(obligations)),
+                new EPPOptions(),
+                new OperationSet("read", "write", "execute"));
         pdp.getEPP().processEvent(new AssignToEvent(new UserContext("u1"), oa2, o1));
 
         assertTrue(graph.exists("new OA"));

--- a/src/test/java/gov/nist/csd/pm/epp/functions/TestUtil.java
+++ b/src/test/java/gov/nist/csd/pm/epp/functions/TestUtil.java
@@ -3,7 +3,10 @@ package gov.nist.csd.pm.epp.functions;
 import gov.nist.csd.pm.epp.EPPOptions;
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.GraphAdmin;
+import gov.nist.csd.pm.pap.ObligationsAdmin;
 import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pap.ProhibitionsAdmin;
 import gov.nist.csd.pm.pdp.PDP;
 import gov.nist.csd.pm.pdp.services.UserContext;
 import gov.nist.csd.pm.pip.graph.Graph;
@@ -13,11 +16,12 @@ import gov.nist.csd.pm.pip.graph.model.nodes.NodeType;
 import gov.nist.csd.pm.pip.obligations.MemObligations;
 import gov.nist.csd.pm.pip.prohibitions.MemProhibitions;
 
-import java.util.Random;
-
 class TestUtil {
     static TestContext getTestCtx() throws PMException {
-        PDP pdp = PDP.newPDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), new EPPOptions(), new OperationSet("read", "write", "execute"));
+        PDP pdp = PDP.newPDP(
+                new PAP(new GraphAdmin(new MemGraph()), new ProhibitionsAdmin(new MemProhibitions()), new ObligationsAdmin(new MemObligations())),
+                new EPPOptions(),
+                new OperationSet("read", "write", "execute"));
         Graph graph = pdp.getGraphService(new UserContext("super"));
         Node pc1 = graph.createPolicyClass("pc1", null);
         Node oa1 = graph.createNode("oa1", NodeType.OA, null, pc1.getName());

--- a/src/test/java/gov/nist/csd/pm/pdp/policy/SuperPolicyTest.java
+++ b/src/test/java/gov/nist/csd/pm/pdp/policy/SuperPolicyTest.java
@@ -1,33 +1,13 @@
 package gov.nist.csd.pm.pdp.policy;
 
-import gov.nist.csd.pm.epp.EPPOptions;
 import gov.nist.csd.pm.exceptions.PMException;
-import gov.nist.csd.pm.operations.OperationSet;
-import gov.nist.csd.pm.pap.PAP;
-import gov.nist.csd.pm.pdp.PDP;
-import gov.nist.csd.pm.pdp.audit.Auditor;
-import gov.nist.csd.pm.pdp.audit.PReviewAuditor;
-import gov.nist.csd.pm.pdp.audit.model.Explain;
-import gov.nist.csd.pm.pdp.decider.Decider;
-import gov.nist.csd.pm.pdp.decider.PReviewDecider;
-import gov.nist.csd.pm.pdp.services.AnalyticsService;
-import gov.nist.csd.pm.pdp.services.UserContext;
+import gov.nist.csd.pm.pap.policies.SuperPolicy;
 import gov.nist.csd.pm.pip.graph.Graph;
 import gov.nist.csd.pm.pip.graph.MemGraph;
-import gov.nist.csd.pm.pip.graph.model.nodes.Node;
-import gov.nist.csd.pm.pip.graph.model.nodes.NodeType;
-import gov.nist.csd.pm.pip.obligations.MemObligations;
-import gov.nist.csd.pm.pip.obligations.Obligations;
-import gov.nist.csd.pm.pip.prohibitions.MemProhibitions;
-import gov.nist.csd.pm.pip.prohibitions.Prohibitions;
-import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.Set;
 
-import static gov.nist.csd.pm.operations.Operations.*;
-import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.O;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SuperPolicyTest {

--- a/src/test/java/gov/nist/csd/pm/pdp/services/GraphServiceTest.java
+++ b/src/test/java/gov/nist/csd/pm/pdp/services/GraphServiceTest.java
@@ -2,7 +2,10 @@ package gov.nist.csd.pm.pdp.services;
 
 import gov.nist.csd.pm.exceptions.PMException;
 import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.GraphAdmin;
+import gov.nist.csd.pm.pap.ObligationsAdmin;
 import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pap.ProhibitionsAdmin;
 import gov.nist.csd.pm.pdp.PDP;
 import gov.nist.csd.pm.pip.graph.Graph;
 import gov.nist.csd.pm.pip.graph.MemGraph;
@@ -18,7 +21,7 @@ class GraphServiceTest {
 
     @Test
     void testPolicyClassReps() throws PMException {
-        PDP pdp = PDP.newPDP(new PAP(new MemGraph(), new MemProhibitions(), new MemObligations()), null, new OperationSet("read", "write", "execute"));
+        PDP pdp = PDP.newPDP(new PAP(new GraphAdmin(new MemGraph()), new ProhibitionsAdmin(new MemProhibitions()), new ObligationsAdmin(new MemObligations())), null, new OperationSet("read", "write", "execute"));
         Graph graph = pdp.getGraphService(new UserContext("super", ""));
 
         Node test = graph.createPolicyClass("test", null);

--- a/src/test/java/gov/nist/csd/pm/pdp/services/guard/GraphGuardTest.java
+++ b/src/test/java/gov/nist/csd/pm/pdp/services/guard/GraphGuardTest.java
@@ -1,0 +1,383 @@
+package gov.nist.csd.pm.pdp.services.guard;
+
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.GraphAdmin;
+import gov.nist.csd.pm.pap.ObligationsAdmin;
+import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pap.ProhibitionsAdmin;
+import gov.nist.csd.pm.pdp.services.UserContext;
+import gov.nist.csd.pm.pip.graph.Graph;
+import gov.nist.csd.pm.pip.graph.MemGraph;
+import gov.nist.csd.pm.pip.graph.model.nodes.Node;
+import gov.nist.csd.pm.pip.obligations.MemObligations;
+import gov.nist.csd.pm.pip.prohibitions.MemProhibitions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static gov.nist.csd.pm.operations.Operations.ALL_ADMIN_OPS;
+import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GraphGuardTest {
+
+    private GraphGuard guard;
+    private static final UserContext u1Ctx = new UserContext("u1");
+    private static final UserContext u2Ctx = new UserContext("u2");
+    private static final UserContext superCtx = new UserContext("super");
+
+    @BeforeEach
+    void setUp() throws PMException {
+        PAP pap = new PAP(
+                new GraphAdmin(new MemGraph()),
+                new ProhibitionsAdmin(new MemProhibitions()),
+                new ObligationsAdmin(new MemObligations())
+        );
+
+        // create graph
+        Graph graph = pap.getGraphAdmin();
+        graph.createPolicyClass("pc1", null);
+        graph.createNode("oa1", OA, null, "pc1");
+        graph.createNode("oa2", OA, null, "pc1");
+        graph.createNode("ua1", UA, null, "pc1");
+        graph.createNode("ua2", UA, null, "pc1");
+        graph.createNode("o1", O, null, "oa1", "oa2");
+        graph.createNode("u1", U, null, "ua1");
+        graph.createNode("u2", U, null, "ua2");
+
+        graph.associate("ua1", "oa1", new OperationSet("read", "write"));
+        graph.associate("ua2", "oa1", new OperationSet(ALL_ADMIN_OPS));
+        graph.associate("ua2", "oa2", new OperationSet(ALL_ADMIN_OPS));
+
+        guard = new GraphGuard(pap, new OperationSet("read", "write"));
+    }
+
+    @Nested
+    class CreatePolicyClass {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkCreatePolicyClass(superCtx));
+        }
+
+        @Test
+        void testU1Error() {
+            assertThrows(PMException.class, () -> guard.checkCreatePolicyClass(u1Ctx));
+        }
+    }
+
+    @Nested
+    class CreateNode {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkCreateNode(superCtx, "oa1", new String[]{"oa2", "pc1_default_OA"}));
+        }
+
+        @Test
+        void testU2CreateNode() {
+            assertDoesNotThrow(() -> guard.checkCreateNode(u2Ctx, "oa1", new String[]{"oa2"}));
+        }
+
+        @Test
+        void testU1CreateNodeError() {
+            assertThrows(PMException.class,
+                    () -> guard.checkCreateNode(u1Ctx, "oa1", null));
+        }
+
+    }
+
+    @Nested
+    class UpdateNode {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkUpdateNode(superCtx, "oa1"));
+            assertDoesNotThrow(() -> guard.checkUpdateNode(superCtx, "pc1"));
+            assertDoesNotThrow(() -> guard.checkUpdateNode(superCtx, "ua1"));
+            assertDoesNotThrow(() -> guard.checkUpdateNode(superCtx, "u1"));
+            assertDoesNotThrow(() -> guard.checkUpdateNode(superCtx, "o1"));
+
+        }
+
+        @Test
+        void testU2UpdateOA1() {
+            assertDoesNotThrow(() -> guard.checkUpdateNode(u2Ctx, "oa1"));
+        }
+
+        @Test
+        void testU1UpdateOA1Error() {
+            assertThrows(PMException.class, () -> guard.checkUpdateNode(u1Ctx, "oa1"));
+        }
+
+
+    }
+
+    @Nested
+    class DeleteNode {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkDeleteNode(superCtx, "oa1"));
+            assertDoesNotThrow(() -> guard.checkDeleteNode(superCtx, "pc1"));
+            assertDoesNotThrow(() -> guard.checkDeleteNode(superCtx, "ua1"));
+            assertDoesNotThrow(() -> guard.checkDeleteNode(superCtx, "u1"));
+            assertDoesNotThrow(() -> guard.checkDeleteNode(superCtx, "o1"));
+
+        }
+
+        @Test
+        void testU2UpdateOA1() {
+            assertThrows(PMException.class, () -> guard.checkDeleteNode(u2Ctx, "oa1"));
+        }
+
+        @Test
+        void testU1UpdateOA1Error() {
+            assertThrows(PMException.class, () -> guard.checkDeleteNode(u1Ctx, "oa1"));
+        }
+
+
+    }
+
+    @Nested
+    class Exists {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkExists(superCtx, "pc1"));
+            assertDoesNotThrow(() -> guard.checkExists(superCtx, "oa1"));
+            assertDoesNotThrow(() -> guard.checkExists(superCtx, "ua1"));
+            assertDoesNotThrow(() -> guard.checkExists(superCtx, "u1"));
+            assertDoesNotThrow(() -> guard.checkExists(superCtx, "o1"));
+
+        }
+
+        @Test
+        void testU2() {
+            assertDoesNotThrow(() -> guard.checkExists(u2Ctx, "oa1"));
+        }
+
+        @Test
+        void testU1Error() {
+            assertThrows(PMException.class, () -> guard.checkExists(u1Ctx, "pc1"));
+        }
+
+    }
+
+    @Nested
+    class FilterStrings {
+
+        @Test
+        void testSuper() throws PMException {
+            Set<String> nodes = new HashSet<>(Arrays.asList("pc1", "oa1", "ua1", "o1", "u1"));
+            guard.filter(superCtx, nodes);
+            assertEquals(5, nodes.size());
+        }
+
+        @Test
+        void testU1() throws PMException {
+            Set<String> nodes = new HashSet<>(Arrays.asList("oa1", "o1"));
+            guard.filter(u1Ctx, nodes);
+            assertEquals(2, nodes.size());
+        }
+
+        @Test
+        void testU2() throws PMException {
+            Set<String> nodes = new HashSet<>(Arrays.asList("oa1", "o1", "oa2"));
+            guard.filter(u2Ctx, nodes);
+            assertEquals(3, nodes.size());
+        }
+
+    }
+
+    @Nested
+    class FilterNodes {
+
+        Set<Node> getNodes() throws PMException {
+            Set<Node> nodes = guard.pap.getGraphAdmin().getNodes();
+            nodes.removeIf(n -> !Arrays.asList("pc1", "oa1", "oa2", "o1", "ua1", "u1").contains(n.getName()));
+            return nodes;
+        }
+
+        @Test
+        void testSuper() throws PMException {
+            Set<Node> nodes = getNodes();
+            guard.filterNodes(superCtx, nodes);
+            assertEquals(6, nodes.size());
+        }
+
+        @Test
+        void testU1() throws PMException {
+            Set<Node> nodes = getNodes();
+            guard.filterNodes(u1Ctx, nodes);
+            assertEquals(2, nodes.size());
+        }
+
+        @Test
+        void testU2() throws PMException {
+            Set<Node> nodes = getNodes();
+            guard.filterNodes(u2Ctx, nodes);
+            assertEquals(3, nodes.size());
+        }
+
+    }
+
+    @Nested
+    class FilterMap {
+
+        @Test
+        void testSuper() throws PMException {
+            Map<String, OperationSet> assocs = guard.pap.getGraphAdmin().getSourceAssociations("ua2");
+            guard.filter(superCtx, assocs);
+            assertEquals(2, assocs.size());
+        }
+
+        @Test
+        void testU1() throws PMException {
+            Map<String, OperationSet> assocs = guard.pap.getGraphAdmin().getSourceAssociations("ua2");
+            guard.filter(u1Ctx, assocs);
+            assertEquals(1, assocs.size());
+        }
+
+        @Test
+        void testU2() throws PMException {
+            Map<String, OperationSet> assocs = guard.pap.getGraphAdmin().getSourceAssociations("ua2");
+            guard.filter(u2Ctx, assocs);
+            assertEquals(2, assocs.size());
+        }
+
+    }
+
+    @Nested
+    class Assign {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkAssign(superCtx, "u1", "ua2"));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkAssign(u1Ctx, "u1", "ua2"));
+            assertThrows(PMException.class, () -> guard.checkAssign(u1Ctx, "oa1", "oa2"));
+        }
+
+        @Test
+        void testU2() {
+            assertThrows(PMException.class, () -> guard.checkAssign(u2Ctx, "u1", "ua2"));
+            assertDoesNotThrow(() -> guard.checkAssign(u2Ctx, "oa1", "oa2"));
+        }
+
+    }
+
+    @Nested
+    class Deassign {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkDeassign(superCtx, "u2", "ua2"));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkDeassign(u1Ctx, "u1", "ua2"));
+            assertThrows(PMException.class, () -> guard.checkDeassign(u1Ctx, "o1", "oa1"));
+            assertThrows(PMException.class, () -> guard.checkDeassign(u1Ctx, "o1", "oa2"));
+        }
+
+        @Test
+        void testU2() {
+            assertThrows(PMException.class, () -> guard.checkDeassign(u2Ctx, "u1", "ua1"));
+            assertThrows(PMException.class, () -> guard.checkDeassign(u2Ctx, "u2", "ua2"));
+            assertDoesNotThrow(() -> guard.checkDeassign(u2Ctx, "o1", "oa2"));
+        }
+
+    }
+
+    @Nested
+    class Associate {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkAssociate(superCtx, "ua1", "oa2"));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkAssociate(u1Ctx, "ua1", "oa2"));
+        }
+
+        @Test
+        void testU2() {
+            assertThrows(PMException.class, () -> guard.checkAssociate(u2Ctx, "ua1", "oa2"));
+        }
+
+    }
+
+    @Nested
+    class Dissociate {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkDissociate(superCtx, "ua1", "oa1"));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkDissociate(u1Ctx, "ua1", "oa1"));
+        }
+
+        @Test
+        void testU2() {
+            assertThrows(PMException.class, () -> guard.checkDissociate(u2Ctx, "ua1", "oa1"));
+        }
+
+    }
+
+    @Nested
+    class GetAssociations {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkGetAssociations(superCtx, "ua1"));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkGetAssociations(u1Ctx, "ua1"));
+        }
+
+        @Test
+        void testU2() {
+            assertThrows(PMException.class, () -> guard.checkGetAssociations(u2Ctx, "ua1"));
+        }
+
+    }
+
+    @Nested
+    class Json {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkToJson(superCtx));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkToJson(u1Ctx));
+        }
+
+        @Test
+        void testU2() {
+            assertThrows(PMException.class, () -> guard.checkToJson(u2Ctx));
+        }
+
+    }
+
+}

--- a/src/test/java/gov/nist/csd/pm/pdp/services/guard/ObligationsGuardTest.java
+++ b/src/test/java/gov/nist/csd/pm/pdp/services/guard/ObligationsGuardTest.java
@@ -1,0 +1,129 @@
+package gov.nist.csd.pm.pdp.services.guard;
+
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.GraphAdmin;
+import gov.nist.csd.pm.pap.ObligationsAdmin;
+import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pap.ProhibitionsAdmin;
+import gov.nist.csd.pm.pdp.services.UserContext;
+import gov.nist.csd.pm.pip.graph.Graph;
+import gov.nist.csd.pm.pip.graph.MemGraph;
+import gov.nist.csd.pm.pip.obligations.MemObligations;
+import gov.nist.csd.pm.pip.prohibitions.MemProhibitions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static gov.nist.csd.pm.operations.Operations.ALL_ADMIN_OPS;
+import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.*;
+import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.U;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ObligationsGuardTest {
+
+    private ObligationsGuard guard;
+    private static final UserContext u1Ctx = new UserContext("u1");
+    private static final UserContext superCtx = new UserContext("super");
+
+    @BeforeEach
+    void setUp() throws PMException {
+        PAP pap = new PAP(
+                new GraphAdmin(new MemGraph()),
+                new ProhibitionsAdmin(new MemProhibitions()),
+                new ObligationsAdmin(new MemObligations())
+        );
+
+        // create graph
+        Graph graph = pap.getGraphAdmin();
+        graph.createPolicyClass("pc1", null);
+        graph.createNode("oa1", OA, null, "pc1");
+        graph.createNode("oa2", OA, null, "pc1");
+        graph.createNode("ua1", UA, null, "pc1");
+        graph.createNode("ua2", UA, null, "pc1");
+        graph.createNode("o1", O, null, "oa1", "oa2");
+        graph.createNode("u1", U, null, "ua1");
+        graph.createNode("u2", U, null, "ua2");
+
+        graph.associate("ua1", "oa1", new OperationSet("read", "write"));
+        graph.associate("ua2", "oa1", new OperationSet(ALL_ADMIN_OPS));
+        graph.associate("ua2", "oa2", new OperationSet(ALL_ADMIN_OPS));
+
+        guard = new ObligationsGuard(pap, new OperationSet("read", "write"));
+    }
+
+    @Nested
+    class checkAdd {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkAdd(superCtx));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkAdd(u1Ctx));
+        }
+
+    }
+
+    @Nested
+    class checkGet {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkGet(superCtx));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkGet(u1Ctx));
+        }
+
+    }
+
+    @Nested
+    class checkUpdate {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkUpdate(superCtx));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkUpdate(u1Ctx));
+        }
+
+    }
+
+    @Nested
+    class checkDelete {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkDelete(superCtx));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkDelete(u1Ctx));
+        }
+
+    }
+
+    @Nested
+    class checkEnable {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkEnable(superCtx));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkEnable(u1Ctx));
+        }
+
+    }
+}

--- a/src/test/java/gov/nist/csd/pm/pdp/services/guard/ProhibitionsGuardTest.java
+++ b/src/test/java/gov/nist/csd/pm/pdp/services/guard/ProhibitionsGuardTest.java
@@ -1,0 +1,187 @@
+package gov.nist.csd.pm.pdp.services.guard;
+
+import gov.nist.csd.pm.exceptions.PMException;
+import gov.nist.csd.pm.operations.OperationSet;
+import gov.nist.csd.pm.pap.GraphAdmin;
+import gov.nist.csd.pm.pap.ObligationsAdmin;
+import gov.nist.csd.pm.pap.PAP;
+import gov.nist.csd.pm.pap.ProhibitionsAdmin;
+import gov.nist.csd.pm.pdp.services.UserContext;
+import gov.nist.csd.pm.pip.graph.Graph;
+import gov.nist.csd.pm.pip.graph.MemGraph;
+import gov.nist.csd.pm.pip.obligations.MemObligations;
+import gov.nist.csd.pm.pip.prohibitions.MemProhibitions;
+import gov.nist.csd.pm.pip.prohibitions.model.Prohibition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static gov.nist.csd.pm.operations.Operations.ALL_ADMIN_OPS;
+import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.*;
+import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.U;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProhibitionsGuardTest {
+
+    private ProhibitionsGuard guard;
+    private static final UserContext u1Ctx = new UserContext("u1");
+    private static final UserContext superCtx = new UserContext("super");
+
+    @BeforeEach
+    void setUp() throws PMException {
+        PAP pap = new PAP(
+                new GraphAdmin(new MemGraph()),
+                new ProhibitionsAdmin(new MemProhibitions()),
+                new ObligationsAdmin(new MemObligations())
+        );
+
+        // create graph
+        Graph graph = pap.getGraphAdmin();
+        graph.createPolicyClass("pc1", null);
+        graph.createNode("oa1", OA, null, "pc1");
+        graph.createNode("oa2", OA, null, "pc1");
+        graph.createNode("ua1", UA, null, "pc1");
+        graph.createNode("ua2", UA, null, "pc1");
+        graph.createNode("o1", O, null, "oa1", "oa2");
+        graph.createNode("u1", U, null, "ua1");
+        graph.createNode("u2", U, null, "ua2");
+
+        graph.associate("ua1", "oa1", new OperationSet("read", "write"));
+        graph.associate("ua2", "oa1", new OperationSet(ALL_ADMIN_OPS));
+        graph.associate("ua2", "oa2", new OperationSet(ALL_ADMIN_OPS));
+
+        guard = new ProhibitionsGuard(pap, new OperationSet("read", "write"));
+    }
+
+    @Nested
+    class checkAdd {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkAdd(superCtx,
+                    new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                            .addContainer("oa1", false)
+                            .addContainer("oa2", true)
+                            .build()
+                    ));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkAdd(u1Ctx,
+                    new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                            .addContainer("oa1", false)
+                            .addContainer("oa2", true)
+                            .build()
+                    ));
+        }
+    }
+
+    @Nested
+    class checkGet {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkGet(superCtx,
+                    new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                            .addContainer("oa1", false)
+                            .addContainer("oa2", true)
+                            .build()
+                    ));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkGet(u1Ctx,
+                    new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                            .addContainer("oa1", false)
+                            .addContainer("oa2", true)
+                            .build()
+                    ));
+        }
+    }
+
+    @Nested
+    class checkUpdate {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkUpdate(superCtx,
+                    new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                            .addContainer("oa1", false)
+                            .addContainer("oa2", true)
+                            .build()
+                    ));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkUpdate(u1Ctx,
+                    new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                            .addContainer("oa1", false)
+                            .addContainer("oa2", true)
+                            .build()
+                    ));
+        }
+    }
+
+    @Nested
+    class checkDelete {
+
+        @Test
+        void testSuper() {
+            assertDoesNotThrow(() -> guard.checkDelete(superCtx,
+                    new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                            .addContainer("oa1", false)
+                            .addContainer("oa2", true)
+                            .build()
+                    ));
+        }
+
+        @Test
+        void testU1() {
+            assertThrows(PMException.class, () -> guard.checkDelete(u1Ctx,
+                    new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                            .addContainer("oa1", false)
+                            .addContainer("oa2", true)
+                            .build()
+                    ));
+        }
+    }
+
+    @Nested
+    class checkFilter {
+
+        @Test
+        void testSuper() {
+            List<Prohibition> prohibitions = new ArrayList<>();
+            prohibitions.add(new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                    .addContainer("oa1", false)
+                    .addContainer("oa2", true)
+                    .build()
+            );
+
+            guard.filter(superCtx, prohibitions);
+
+            assertFalse(prohibitions.isEmpty());
+        }
+
+        @Test
+        void testU1() {
+            List<Prohibition> prohibitions = new ArrayList<>();
+            prohibitions.add(new Prohibition.Builder("super-test", "ua1", new OperationSet("read"))
+                    .addContainer("oa1", false)
+                    .addContainer("oa2", true)
+                    .build()
+            );
+
+            guard.filter(u1Ctx, prohibitions);
+
+            assertTrue(prohibitions.isEmpty());
+        }
+    }
+
+}


### PR DESCRIPTION
fixes #61 

Moves the embedded graph configurations from the PDP to the PAP.  It makes more sense to have this in the administration point rather than the decision point.  This includes the Super policy configuration. The Service classes in the PDP should do two things 1) check the user has access and 2) if the user does have access, pass the request to the PAP. 