### PR TITLE
Obligation fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,5 +83,10 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.24</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
@@ -157,11 +157,7 @@ public class GraphService extends Service implements Graph {
             return false;
         }
 
-        // check that this user can access this node
-        guard.checkExists(userCtx, name);
-
-        // if the user can access this node than return true
-        return true;
+        return guard.checkExists(userCtx, name);
     }
 
     /**

--- a/src/main/java/gov/nist/csd/pm/pdp/services/guard/GraphGuard.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/guard/GraphGuard.java
@@ -66,14 +66,11 @@ public class GraphGuard extends Guard {
         }
     }
 
-    public void checkExists(UserContext userCtx, String name) throws PMException {
+    public boolean checkExists(UserContext userCtx, String name) throws PMException {
         // a user only needs one permission to know a node exists
         // however receiving an unauthorized exception would let the user know it exists
-        // therefore, a general PMException is thrown indicating that the node may not exist or
-        // the user may not have permissions
-        if(!hasPermissions(userCtx, name)) {
-            throw new PMException(name + " does not exist or " + userCtx + " is not authorized");
-        }
+        // therefore, false is returned if they don't have permissions on the node
+        return hasPermissions(userCtx, name);
     }
 
     public void filter(UserContext userCtx, Set<String> nodes) throws PMException {

--- a/src/main/java/gov/nist/csd/pm/pip/obligations/MemObligations.java
+++ b/src/main/java/gov/nist/csd/pm/pip/obligations/MemObligations.java
@@ -23,13 +23,7 @@ public class MemObligations implements Obligations {
 
     @Override
     public Obligation get(String label) {
-        for(String l : obligations.keySet()) {
-            if(l.equals(label)) {
-                return obligations.get(l);
-            }
-        }
-
-        return null;
+        return obligations.get(label);
     }
 
     @Override
@@ -39,7 +33,15 @@ public class MemObligations implements Obligations {
 
     @Override
     public void update(String label, Obligation obligation) {
-        obligations.put(label, obligation);
+        String updatedLabel = obligation.getLabel();
+        if (updatedLabel != null && !updatedLabel.equals(label)) {
+            obligations.remove(label);
+        } else if (updatedLabel == null) {
+            // update the obligations label with the provided label if it's not set
+            obligation.setLabel(label);
+        }
+
+        obligations.put(obligation.getLabel(), obligation);
     }
 
     @Override

--- a/src/main/java/gov/nist/csd/pm/pip/obligations/Obligations.java
+++ b/src/main/java/gov/nist/csd/pm/pip/obligations/Obligations.java
@@ -6,18 +6,59 @@ import gov.nist.csd.pm.pip.obligations.model.Obligation;
 import java.util.List;
 
 public interface Obligations {
+
+    /**
+     * Add the given obligation and enable it if the enable flag is true.
+     * @param obligation the obligation to add
+     * @param enable if true enable the obligation, else do not enable it
+     * @throws PMException
+     */
     void add(Obligation obligation, boolean enable) throws PMException;
 
+    /**
+     * Retrieves the obligation with the given label
+     * @param label the label of the obligation to retrieve
+     * @return the obligation with the given label
+     * @throws PMException
+     */
     Obligation get(String label) throws PMException;
 
+    /**
+     * Return all obligations
+     * @return all obligations
+     * @throws PMException
+     */
     List<Obligation> getAll() throws PMException;
 
+    /**
+     * Update the obligation with the given label.  If the label in the provided object is not null and different from
+     * the label parameter, the label will also be updated.
+     * @param label the label of the obligation to update
+     * @param obligation the updated obligation
+     * @throws PMException
+     */
     void update(String label, Obligation obligation) throws PMException;
 
+    /**
+     * Delete the obligation with the given label.
+     * @param label the label of the obligation to delete
+     * @throws PMException
+     */
     void delete(String label) throws PMException;
 
+    /**
+     * Set the enable flag of the obligation with the given label.
+     * @param label the label of the obligation to set the enable flag for
+     * @param enabled the boolean flag to set for the given obligation
+     * @throws PMException
+     */
     void setEnable(String label, boolean enabled) throws PMException;
 
+    /**
+     * Returns all enabled obligations
+     * @return all obligations that have a true enabled value
+     * @throws PMException
+     */
     List<Obligation> getEnabled() throws PMException;
 
 }

--- a/src/main/java/gov/nist/csd/pm/pip/obligations/README.md
+++ b/src/main/java/gov/nist/csd/pm/pip/obligations/README.md
@@ -64,7 +64,7 @@ There is one obligation per yaml file. An obligation can have zero or more rules
 label:
 rules:
 ```
-- **_label_** - A label to give the obligation.  If one is not specified, then a random value will be used.
+- **_label_** *(required)* - A label to give the obligation.
 - **_rules_** - Contains a set of zero or more rules.
 
 ##  Rule
@@ -73,7 +73,7 @@ label:
 event:
 response:
 ```
-- **_label_** - A label to give the rule.  If one is not specified a random value will be used.
+- **_label_** *(required)* - A label to give the rule.  If one is not specified a random value will be used.
 - **_event_** - The event pattern for this rule.
 - **_response_** - The response to the event.
 
@@ -247,7 +247,7 @@ actions:
 
 - a set of rules
 - a set of nodes
-#### rule
+#### rules
 ```yaml
 create:
   - label:

--- a/src/main/java/gov/nist/csd/pm/pip/obligations/evr/EVRParser.java
+++ b/src/main/java/gov/nist/csd/pm/pip/obligations/evr/EVRParser.java
@@ -37,23 +37,8 @@ public class EVRParser {
     public Obligation parse(String user, String yml) throws EVRException {
         Yaml yaml = new Yaml();
         Map<Object, Object> map = yaml.load(yml);
-
-        return parse(user, map);
-    }
-
-    /**
-     * label: string required
-     * rules: array
-     */
-    public Obligation parse(String user, InputStream is) throws EVRException {
-        Yaml yaml = new Yaml();
-        Map<Object, Object> map = yaml.load(is);
-
-        return parse(user, map);
-    }
-
-    private Obligation parse(String user, Map<Object, Object> map) throws EVRException {
         Obligation obligation = new Obligation(user);
+        obligation.setSource(yml);
 
         String label = getObject(map.get("label"), String.class);
         if (label == null) {

--- a/src/test/java/gov/nist/csd/pm/epp/EPPTest.java
+++ b/src/test/java/gov/nist/csd/pm/epp/EPPTest.java
@@ -21,10 +21,13 @@ import gov.nist.csd.pm.pip.obligations.evr.EVRParser;
 import gov.nist.csd.pm.pip.obligations.model.Obligation;
 import gov.nist.csd.pm.pip.obligations.model.Rule;
 import gov.nist.csd.pm.pip.prohibitions.MemProhibitions;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static gov.nist.csd.pm.pip.graph.model.nodes.NodeType.*;
@@ -60,9 +63,10 @@ class EPPTest {
     }
 
     @Test
-    void TestEvent() throws PMException {
+    void TestEvent() throws PMException, IOException {
         InputStream is = getClass().getClassLoader().getResourceAsStream("epp/event_test.yml");
-        Obligation obligation = new EVRParser().parse("super", is);
+        String yml = IOUtils.toString(is, StandardCharsets.UTF_8.name());
+        Obligation obligation = new EVRParser().parse("super", yml);
 
         UserContext superCtx = new UserContext("super");
         pdp.getObligationsService(superCtx).add(obligation, true);
@@ -83,11 +87,12 @@ class EPPTest {
     }
 
     @Test
-    void TestResponse() throws PMException {
+    void TestResponse() throws PMException, IOException {
         InputStream is = getClass().getClassLoader().getResourceAsStream("epp/response_test.yml");
+        String yml = IOUtils.toString(is, StandardCharsets.UTF_8.name());
         UserContext superCtx = new UserContext("super");
 
-        Obligation obligation = new EVRParser().parse(superCtx.getUser(), is);
+        Obligation obligation = new EVRParser().parse(superCtx.getUser(), yml);
         pdp.getObligationsService(superCtx).add(obligation, true);
 
         pdp.getEPP().processEvent(new AssignToEvent(new UserContext(u1.getName(), "123"), oa1, o1));
@@ -122,7 +127,7 @@ class EPPTest {
     }
 
     @Test
-    void testUserContainedIn() throws PMException {
+    void testUserContainedIn() throws PMException, IOException {
         Graph graph = new MemGraph();
 
         graph.createPolicyClass("pc1", null);
@@ -135,7 +140,8 @@ class EPPTest {
         graph.createNode("u1", U, null, "ua1-1");
 
         InputStream is = getClass().getClassLoader().getResourceAsStream("epp/UserContainedIn.yml");
-        Obligation obligation = new EVRParser().parse("super", is);
+        String yml = IOUtils.toString(is, StandardCharsets.UTF_8.name());
+        Obligation obligation = new EVRParser().parse("super", yml);
 
         Obligations obligations = new MemObligations();
         obligations.add(obligation, true);

--- a/src/test/java/gov/nist/csd/pm/pdp/services/guard/GraphGuardTest.java
+++ b/src/test/java/gov/nist/csd/pm/pdp/services/guard/GraphGuardTest.java
@@ -164,8 +164,8 @@ class GraphGuardTest {
         }
 
         @Test
-        void testU1Error() {
-            assertThrows(PMException.class, () -> guard.checkExists(u1Ctx, "pc1"));
+        void testU1Error() throws PMException {
+            assertFalse(guard.checkExists(u1Ctx, "pc1"));
         }
 
     }


### PR DESCRIPTION
fixes #75 and #76 

- There was an error in the docs which incorrectly stated that random labels are created for obligations if one is not provided.  This has been fixed.
- When updating obligations in memory there was a chance that the provided label was different than the one in the obligtion object which could cause problems
- Fixed the PDP exist method to return false if the user doesn't have permission or the node doesn't exist instead of throwing an exception