### PR TITLE
exception when deleting nodes with children

### DIFF
--- a/src/main/java/gov/nist/csd/pm/pap/GraphAdmin.java
+++ b/src/main/java/gov/nist/csd/pm/pap/GraphAdmin.java
@@ -118,6 +118,10 @@ public class GraphAdmin implements Graph {
 
     @Override
     public void deleteNode(String name) throws PMException {
+        if (graph.getChildren(name).size() != 0) {
+            throw new PMException("cannot delete " + name + ", nodes are still assigned to it");
+        }
+
         graph.deleteNode(name);
     }
 

--- a/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/services/GraphService.java
@@ -122,6 +122,11 @@ public class GraphService extends Service implements Graph {
         // check that the user can delete the node
         guard.checkDeleteNode(userCtx, name);
 
+        // check that the node does not have any children
+        if (graph.getChildren(name).size() != 0) {
+            throw new PMException("cannot delete " + name + ", nodes are still assigned to it");
+        }
+
         Node node = graph.getNode(name);
 
         // if it's a PC, delete the rep

--- a/src/main/java/gov/nist/csd/pm/pip/graph/Graph.java
+++ b/src/main/java/gov/nist/csd/pm/pip/graph/Graph.java
@@ -47,9 +47,10 @@ public interface Graph {
     void updateNode(String name, Map<String, String> properties) throws PMException;
 
     /**
-     * Delete the node with the given name from the graph.
+     * Delete the node with the given name from the graph. The node must not have any other nodes assigned to it.
      *
      * @param name the name of the node to delete.
+     * @throws PMException if the node being deleted still has other nodes assigned to it.
      * @throws PMException if there is an error deleting the node from the graph.
      */
     void deleteNode(String name) throws PMException;

--- a/src/main/java/gov/nist/csd/pm/pip/graph/MemGraph.java
+++ b/src/main/java/gov/nist/csd/pm/pip/graph/MemGraph.java
@@ -137,7 +137,11 @@ public class MemGraph implements Graph {
      * @param name the name of the node to delete.
      */
     @Override
-    public void deleteNode(String name) {
+    public void deleteNode(String name) throws PMException {
+        if (graph.incomingEdgesOf(name).size() != 0) {
+            throw new PMException("cannot delete " + name + ", nodes are still assigned to it");
+        }
+
         //remove the vertex from the graph
         graph.removeVertex(name);
         //remove the node from the policies if it is a policy class


### PR DESCRIPTION
fixes #73 

When deleting a node that has children an exception is now thrown indicating that all assignments to the node must be deleted first.  This avoids the case where the node to delete is the only parent of a node, and once deleted, causes the child node to be "floating"