### PR TITLE
fix dissociate/deassign error

### DIFF
--- a/src/main/java/gov/nist/csd/pm/pip/graph/MemGraph.java
+++ b/src/main/java/gov/nist/csd/pm/pip/graph/MemGraph.java
@@ -320,16 +320,17 @@ public class MemGraph implements Graph {
      */
     @Override
     public void deassign(String child, String parent) {
-        graph.removeEdge(child, parent);
+        graph.removeEdge(new Assignment(child, parent));
     }
 
     @Override
     public boolean isAssigned(String child, String parent) throws PMException {
-        return graph.containsEdge(child, parent);
+        return graph.containsEdge(new Assignment(child, parent));
     }
 
     /**
-     * Associate the user attribute node and the target node.
+     * Associate the user attribute node and the target node. If an association already exists, the operations will
+     * be updated with the given operations.
      *
      * @throws PMException              if the user attribute node does not exist in the graph.
      * @throws PMException              if the target node does not exist in the graph.
@@ -367,7 +368,7 @@ public class MemGraph implements Graph {
      */
     @Override
     public void dissociate(String ua, String target) {
-        graph.removeEdge(ua, target);
+        graph.removeEdge(new Association(ua, target));
     }
 
     /**
@@ -449,7 +450,6 @@ public class MemGraph implements Graph {
         JsonGraph jsonGraph = new Gson().fromJson(json, JsonGraph.class);
 
         Collection<Node> nodes = jsonGraph.getNodes();
-        Map<String, Node> nodesMap = new HashMap<>();
         for (Node node : nodes) {
             if (node.getType().equals(PC)) {
                 this.createPolicyClass(node.getName(), node.getProperties());

--- a/src/main/java/gov/nist/csd/pm/pip/graph/model/relationships/Association.java
+++ b/src/main/java/gov/nist/csd/pm/pip/graph/model/relationships/Association.java
@@ -33,6 +33,11 @@ public class Association extends Relationship implements Serializable {
         this.operations = operations;
     }
 
+    public Association(String ua, String target) {
+        super(ua, target);
+        this.operations = new OperationSet();
+    }
+
     public OperationSet getOperations() {
         return operations;
     }
@@ -68,12 +73,11 @@ public class Association extends Relationship implements Serializable {
 
         Association association = (Association) o;
         return this.source.equals(association.source) &&
-                this.target.equals(association.target) &&
-                this.operations.equals(association.operations);
+                this.target.equals(association.target);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(source, target, operations);
+        return Objects.hash(source, target);
     }
 }

--- a/src/test/java/gov/nist/csd/pm/pip/graph/MemGraphTest.java
+++ b/src/test/java/gov/nist/csd/pm/pip/graph/MemGraphTest.java
@@ -283,4 +283,24 @@ class MemGraphTest {
         assertEquals("pc", node.getName());
         assertEquals(PC, node.getType());
     }
+
+    @Test
+    void testParallelEdges() throws PMException {
+        Graph graph = new MemGraph();
+        graph.createPolicyClass("pc1", null);
+        graph.createNode("ua1", UA, null, "pc1");
+        graph.createNode("ua2", UA, null, "ua1");
+        graph.createNode("u1", U, null, "ua2");
+        graph.associate("ua2", "ua1", new OperationSet("r"));
+        graph.dissociate("ua2", "ua1");
+
+        assertTrue(graph.isAssigned("ua2", "ua1"));
+        assertFalse(graph.getSourceAssociations("ua2").containsKey("ua1"));
+
+        graph.associate("ua2", "ua1", new OperationSet("r"));
+        graph.deassign("ua2", "ua1");
+
+        assertFalse(graph.isAssigned("ua2", "ua1"));
+        assertTrue(graph.getSourceAssociations("ua2").containsKey("ua1"));
+    }
 }


### PR DESCRIPTION
fixes an error when deleting an association or assignment with parallel edges.  Since there are two edges between two nodes, it would just delete the first one regardless of type.