### PR TITLE
[#138] Fix NullPointerException for resource access rights

### DIFF
--- a/src/main/java/gov/nist/csd/pm/policy/author/pal/compiler/visitor/SetResourceAccessRightsStmtVisitor.java
+++ b/src/main/java/gov/nist/csd/pm/policy/author/pal/compiler/visitor/SetResourceAccessRightsStmtVisitor.java
@@ -7,6 +7,7 @@ import gov.nist.csd.pm.policy.author.pal.antlr.PALParser;
 import gov.nist.csd.pm.policy.author.pal.model.context.VisitorContext;
 import gov.nist.csd.pm.policy.author.pal.statement.SetResourceAccessRightsStatement;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SetResourceAccessRightsStmtVisitor extends PALBaseVisitor<SetResourceAccessRightsStatement> {
@@ -25,7 +26,13 @@ public class SetResourceAccessRightsStmtVisitor extends PALBaseVisitor<SetResour
         }
 
         Expression expression = Expression.compileArray(visitorCtx, ctx.expressionArray(), Type.string());
-        List<Expression> exprList = expression.getExprList();
+        List<Expression> exprList = null;
+        if (expression.isLiteral()) {
+            exprList = new ArrayList<>();
+            exprList.add(expression);
+        } else {
+            exprList = expression.getExprList();
+        }
 
         visitorCtx.scope().setResourceAccessRightsExpression(exprList);
 


### PR DESCRIPTION
When setting the resource access rights, the `execute(...)` function needs to check if an array or singular value has been stored in  the `Value`. If it is an array, each value in the array needs to be added to the exprList.