### PR TITLE
remove synchronization from memory methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
                 <version>3.10.1</version>
                 <inherited>true</inherited>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/gov/nist/csd/pm/pap/PAP.java
+++ b/src/main/java/gov/nist/csd/pm/pap/PAP.java
@@ -66,7 +66,7 @@ public class PAP implements PolicySync, PolicyEventListener, PolicyEventEmitter,
     }
 
     @Override
-    public synchronized void addEventListener(PolicyEventListener listener, boolean sync) throws PMException {
+    public void addEventListener(PolicyEventListener listener, boolean sync) throws PMException {
         listeners.add(listener);
 
         if (sync) {
@@ -75,12 +75,12 @@ public class PAP implements PolicySync, PolicyEventListener, PolicyEventEmitter,
     }
 
     @Override
-    public synchronized void removeEventListener(PolicyEventListener listener) {
+    public void removeEventListener(PolicyEventListener listener) {
         listeners.remove(listener);
     }
 
     @Override
-    public synchronized void emitEvent(PolicyEvent event) throws PMException {
+    public void emitEvent(PolicyEvent event) throws PMException {
         for (PolicyEventListener listener : listeners) {
             listener.handlePolicyEvent(event);
         }
@@ -94,26 +94,26 @@ public class PAP implements PolicySync, PolicyEventListener, PolicyEventEmitter,
     }
 
     @Override
-    public synchronized PolicySynchronizationEvent policySync() throws PMException {
+    public PolicySynchronizationEvent policySync() throws PMException {
         return this.policyStore.policySync();
     }
 
     @Override
-    public synchronized void beginTx() throws PMException {
+    public void beginTx() throws PMException {
         policyStore.beginTx();
 
         emitEvent(new BeginTxEvent());
     }
 
     @Override
-    public synchronized void commit() throws PMException {
+    public void commit() throws PMException {
         policyStore.commit();
 
         emitEvent(new CommitTxEvent());
     }
 
     @Override
-    public synchronized void rollback() throws PMException {
+    public void rollback() throws PMException {
         policyStore.rollback();
 
         emitEvent(new RollbackTxEvent(this));

--- a/src/main/java/gov/nist/csd/pm/pap/PAPGraph.java
+++ b/src/main/java/gov/nist/csd/pm/pap/PAPGraph.java
@@ -38,7 +38,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void setResourceAccessRights(AccessRightSet accessRightSet) throws PMException {
+    public void setResourceAccessRights(AccessRightSet accessRightSet) throws PMException {
         for (String ar : accessRightSet) {
             if (isAdminAccessRight(ar) || isWildcardAccessRight(ar)) {
                 throw new AdminAccessRightExistsException(ar);
@@ -52,12 +52,12 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized AccessRightSet getResourceAccessRights() throws PMException {
+    public AccessRightSet getResourceAccessRights() throws PMException {
         return policyStore.graph().getResourceAccessRights();
     }
 
     @Override
-    public synchronized String createPolicyClass(String name, Map<String, String> properties) throws PMException {
+    public String createPolicyClass(String name, Map<String, String> properties) throws PMException {
         if (nodeExists(name)) {
             if (SuperPolicy.isSuperPolicyNode(name)) {
                 return name;
@@ -75,47 +75,47 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized String createPolicyClass(String name) throws PMException {
+    public String createPolicyClass(String name) throws PMException {
         return createPolicyClass(name, NO_PROPERTIES);
     }
 
     @Override
-    public synchronized String createUserAttribute(String name, Map<String, String> properties, String parent, String... parents) throws PMException {
+    public String createUserAttribute(String name, Map<String, String> properties, String parent, String... parents) throws PMException {
         return createNode(name, UA, properties, parent, parents);
     }
 
     @Override
-    public synchronized String createUserAttribute(String name, String parent, String... parents) throws PMException {
+    public String createUserAttribute(String name, String parent, String... parents) throws PMException {
         return createUserAttribute(name, NO_PROPERTIES, parent, parents);
     }
 
     @Override
-    public synchronized String createObjectAttribute(String name, Map<String, String> properties, String parent, String... parents) throws PMException {
+    public String createObjectAttribute(String name, Map<String, String> properties, String parent, String... parents) throws PMException {
         return createNode(name, OA, properties, parent, parents);
     }
 
     @Override
-    public synchronized String createObjectAttribute(String name, String parent, String... parents) throws PMException {
+    public String createObjectAttribute(String name, String parent, String... parents) throws PMException {
         return createObjectAttribute(name, NO_PROPERTIES, parent, parents);
     }
 
     @Override
-    public synchronized String createObject(String name, Map<String, String> properties, String parent, String... parents) throws PMException {
+    public String createObject(String name, Map<String, String> properties, String parent, String... parents) throws PMException {
         return createNode(name, O, properties, parent, parents);
     }
 
     @Override
-    public synchronized String createObject(String name, String parent, String... parents) throws PMException {
+    public String createObject(String name, String parent, String... parents) throws PMException {
         return createObject(name, NO_PROPERTIES, parent, parents);
     }
 
     @Override
-    public synchronized String createUser(String name, Map<String, String> properties, String parent, String... parents) throws PMException {
+    public String createUser(String name, Map<String, String> properties, String parent, String... parents) throws PMException {
         return createNode(name, U, properties, parent, parents);
     }
 
     @Override
-    public synchronized String createUser(String name, String parent, String... parents) throws PMException {
+    public String createUser(String name, String parent, String... parents) throws PMException {
         return createUser(name, NO_PROPERTIES, parent, parents);
     }
 
@@ -175,7 +175,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void setNodeProperties(String name, Map<String, String> properties) throws PMException {
+    public void setNodeProperties(String name, Map<String, String> properties) throws PMException {
         if (!nodeExists(name)) {
             throw new NodeDoesNotExistException(name);
         }
@@ -186,12 +186,12 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized boolean nodeExists(String name) throws PMException {
+    public boolean nodeExists(String name) throws PMException {
         return policyStore.graph().nodeExists(name);
     }
 
     @Override
-    public synchronized Node getNode(String name) throws PMException {
+    public Node getNode(String name) throws PMException {
         if (!nodeExists(name)) {
             throw new NodeDoesNotExistException(name);
         }
@@ -200,17 +200,17 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized List<String> search(NodeType type, Map<String, String> properties) throws PMException {
+    public List<String> search(NodeType type, Map<String, String> properties) throws PMException {
         return policyStore.graph().search(type, properties);
     }
 
     @Override
-    public synchronized List<String> getPolicyClasses() throws PMException {
+    public List<String> getPolicyClasses() throws PMException {
         return policyStore.graph().getPolicyClasses();
     }
 
     @Override
-    public synchronized void deleteNode(String name) throws PMException {
+    public void deleteNode(String name) throws PMException {
         if (!nodeExists(name)) {
             return;
         }
@@ -302,7 +302,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void assign(String child, String parent) throws PMException {
+    public void assign(String child, String parent) throws PMException {
         Node childNode = getNode(child);
         Node parentNode = getNode(parent);
 
@@ -328,7 +328,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
 
 
     @Override
-    public synchronized void deassign(String child, String parent) throws PMException {
+    public void deassign(String child, String parent) throws PMException {
         if ((!nodeExists(child) || !nodeExists(parent))
                 || (!getParents(child).contains(parent))) {
             return;
@@ -391,7 +391,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized List<String> getChildren(String node) throws PMException {
+    public List<String> getChildren(String node) throws PMException {
         if (!nodeExists(node)) {
             throw new NodeDoesNotExistException(node);
         }
@@ -400,7 +400,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void associate(String ua, String target, AccessRightSet accessRights) throws PMException {
+    public void associate(String ua, String target, AccessRightSet accessRights) throws PMException {
         Node uaNode = getNode(ua);
         Node targetNode = getNode(target);
 
@@ -428,7 +428,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void dissociate(String ua, String target) throws PMException {
+    public void dissociate(String ua, String target) throws PMException {
         if ((!nodeExists(ua) || !nodeExists(target))
                 || (!getAssociationsWithSource(ua).contains(new Association(ua, target)))) {
             return;
@@ -440,7 +440,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized List<String> getParents(String node) throws PMException {
+    public List<String> getParents(String node) throws PMException {
         if (!nodeExists(node)) {
             throw new NodeDoesNotExistException(node);
         }
@@ -449,7 +449,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized List<Association> getAssociationsWithSource(String ua) throws PMException {
+    public List<Association> getAssociationsWithSource(String ua) throws PMException {
         if (!nodeExists(ua)) {
             throw new NodeDoesNotExistException(ua);
         }
@@ -458,7 +458,7 @@ class PAPGraph implements Graph, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized List<Association> getAssociationsWithTarget(String target) throws PMException {
+    public List<Association> getAssociationsWithTarget(String target) throws PMException {
         if (!nodeExists(target)) {
             throw new NodeDoesNotExistException(target);
         }

--- a/src/main/java/gov/nist/csd/pm/pap/PAPObligations.java
+++ b/src/main/java/gov/nist/csd/pm/pap/PAPObligations.java
@@ -26,7 +26,7 @@ class PAPObligations implements Obligations, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void create(UserContext author, String label, Rule... rules) throws PMException {
+    public void create(UserContext author, String label, Rule... rules) throws PMException {
         if (exists(label)) {
             throw new ObligationExistsException(label);
         }
@@ -96,7 +96,7 @@ class PAPObligations implements Obligations, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void update(UserContext author, String label, Rule... rules) throws PMException {
+    public void update(UserContext author, String label, Rule... rules) throws PMException {
         if (!exists(label)) {
             throw new ObligationDoesNotExistException(label);
         }
@@ -110,7 +110,7 @@ class PAPObligations implements Obligations, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void delete(String label) throws PMException {
+    public void delete(String label) throws PMException {
         if (!exists(label)) {
             return;
         }
@@ -123,12 +123,12 @@ class PAPObligations implements Obligations, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized List<Obligation> getAll() throws PMException {
+    public List<Obligation> getAll() throws PMException {
         return policyStore.obligations().getAll();
     }
 
     @Override
-    public synchronized Obligation get(String label) throws PMException {
+    public Obligation get(String label) throws PMException {
         if (!exists(label)) {
             throw new ObligationDoesNotExistException(label);
         }

--- a/src/main/java/gov/nist/csd/pm/pap/PAPProhibitions.java
+++ b/src/main/java/gov/nist/csd/pm/pap/PAPProhibitions.java
@@ -24,7 +24,7 @@ class PAPProhibitions implements Prohibitions, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void create(String label, ProhibitionSubject subject, AccessRightSet accessRightSet, boolean intersection, ContainerCondition... containerConditions) throws PMException {
+    public void create(String label, ProhibitionSubject subject, AccessRightSet accessRightSet, boolean intersection, ContainerCondition... containerConditions) throws PMException {
         if (exists(label)) {
             throw new ProhibitionExistsException(label);
         }
@@ -39,7 +39,7 @@ class PAPProhibitions implements Prohibitions, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void update(String label, ProhibitionSubject subject, AccessRightSet accessRightSet, boolean intersection, ContainerCondition... containerConditions) throws PMException {
+    public void update(String label, ProhibitionSubject subject, AccessRightSet accessRightSet, boolean intersection, ContainerCondition... containerConditions) throws PMException {
         checkProhibitionParameters(subject, accessRightSet, containerConditions);
 
         policyStore.prohibitions().update(label, subject, accessRightSet, intersection, containerConditions);
@@ -72,7 +72,7 @@ class PAPProhibitions implements Prohibitions, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized void delete(String label) throws PMException {
+    public void delete(String label) throws PMException {
         if (!exists(label)) {
             return;
         }
@@ -85,7 +85,7 @@ class PAPProhibitions implements Prohibitions, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized Map<String, List<Prohibition>> getAll() throws PMException {
+    public Map<String, List<Prohibition>> getAll() throws PMException {
         return policyStore.prohibitions().getAll();
     }
 
@@ -95,12 +95,12 @@ class PAPProhibitions implements Prohibitions, PolicyEventEmitter {
     }
 
     @Override
-    public synchronized List<Prohibition> getWithSubject(String subject) throws PMException {
+    public List<Prohibition> getWithSubject(String subject) throws PMException {
         return policyStore.prohibitions().getWithSubject(subject);
     }
 
     @Override
-    public synchronized Prohibition get(String label) throws PMException {
+    public Prohibition get(String label) throws PMException {
         Prohibition prohibition = getProhibitionOrNull(label);
         if (prohibition == null) {
             throw new ProhibitionDoesNotExistException(label);

--- a/src/main/java/gov/nist/csd/pm/pap/memory/MemoryPolicyStoreEventHandler.java
+++ b/src/main/java/gov/nist/csd/pm/pap/memory/MemoryPolicyStoreEventHandler.java
@@ -10,7 +10,7 @@ public class MemoryPolicyStoreEventHandler extends BasePolicyEventHandler {
     }
 
     @Override
-    public synchronized void handlePolicyEvent(PolicyEvent event) throws PMException {
+    public void handlePolicyEvent(PolicyEvent event) throws PMException {
         if (event instanceof PolicySynchronizationEvent policySynchronizationEvent) {
             policy = policySynchronizationEvent.getPolicyStore();
         } else {

--- a/src/main/java/gov/nist/csd/pm/pdp/memory/BulkPolicyReviewer.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/memory/BulkPolicyReviewer.java
@@ -31,7 +31,7 @@ public class BulkPolicyReviewer extends MemoryPolicyReviewer {
     }
 
     @Override
-    public synchronized AccessRightSet getAccessRights(UserContext userCtx, String target) throws PMException {
+    public AccessRightSet getAccessRights(UserContext userCtx, String target) throws PMException {
         AccessRightSet accessRights = new AccessRightSet();
 
         UserDagResult userDagResult = userDagEventListener.userDagResult;

--- a/src/main/java/gov/nist/csd/pm/pdp/memory/MemoryPDP.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/memory/MemoryPDP.java
@@ -31,7 +31,7 @@ public class MemoryPDP extends PDP {
         return new MemoryPolicyReviewer(policyEventHandler);
     }
 
-    public synchronized void runTx(UserContext userCtx, PDPTxRunner txRunner) throws PMException {
+    public void runTx(UserContext userCtx, PDPTxRunner txRunner) throws PMException {
         TxRunner.runTx(pap, () -> {
             PDPTx pdpTx = new PDPTx(userCtx, pap, new BulkPolicyReviewer(userCtx, pap), eventListeners);
             txRunner.run(pdpTx);
@@ -45,7 +45,7 @@ public class MemoryPDP extends PDP {
         }
 
         @Override
-        public synchronized void handlePolicyEvent(PolicyEvent event) throws PMException {
+        public void handlePolicyEvent(PolicyEvent event) throws PMException {
             // ignore begin and commit events
             // reviewer will operate as all events are added to the policy
             // in the event of rollback it will call policySync to rollback

--- a/src/main/java/gov/nist/csd/pm/pdp/memory/MemoryPolicyReviewer.java
+++ b/src/main/java/gov/nist/csd/pm/pdp/memory/MemoryPolicyReviewer.java
@@ -47,7 +47,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized AccessRightSet getAccessRights(UserContext userCtx, String target) throws PMException {
+    public AccessRightSet getAccessRights(UserContext userCtx, String target) throws PMException {
         AccessRightSet accessRights = new AccessRightSet();
 
         // traverse the user side of the graph to get the associations
@@ -255,7 +255,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized Map<String, AccessRightSet> buildCapabilityList(UserContext userCtx) throws PMException {
+    public Map<String, AccessRightSet> buildCapabilityList(UserContext userCtx) throws PMException {
         Map<String, AccessRightSet> results = new HashMap<>();
 
         //get border nodes.  Can be OA or UA.  Return empty set if no OAs are reachable
@@ -289,7 +289,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized Map<String, AccessRightSet> buildACL(String target) throws PMException {
+    public Map<String, AccessRightSet> buildACL(String target) throws PMException {
         Map<String, AccessRightSet> acl = new HashMap<>();
         List<String> search = policy.graph().search(U, NO_PROPERTIES);
         for (String user : search) {
@@ -301,13 +301,13 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized Map<String, AccessRightSet> getBorderAttributes(String user) throws PMException {
+    public Map<String, AccessRightSet> getBorderAttributes(String user) throws PMException {
         return processUserDAG(user, NO_PROCESS)
                 .borderTargets();
     }
 
     @Override
-    public synchronized Map<String, AccessRightSet> getSubgraphAccessRights(UserContext userCtx, String root) throws PMException {
+    public Map<String, AccessRightSet> getSubgraphAccessRights(UserContext userCtx, String root) throws PMException {
         Map<String, AccessRightSet> results = new HashMap<>();
 
         UserDagResult userDagResult = processUserDAG(userCtx.getUser(), userCtx.getProcess());
@@ -329,7 +329,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized Explain explain(UserContext userCtx, String target) throws PMException {
+    public Explain explain(UserContext userCtx, String target) throws PMException {
         Node userNode = policy.graph().getNode(userCtx.getUser());
         Node targetNode = policy.graph().getNode(target);
 
@@ -751,7 +751,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized List<String> getAttributeContainers(String node) throws PMException {
+    public List<String> getAttributeContainers(String node) throws PMException {
         List<String> attrs = new ArrayList<>();
 
         new DepthFirstGraphWalker(policy.graph())
@@ -770,7 +770,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized List<String> getPolicyClassContainers(String node) throws PMException {
+    public List<String> getPolicyClassContainers(String node) throws PMException {
         List<String> attrs = new ArrayList<>();
 
         new DepthFirstGraphWalker(policy.graph())
@@ -788,7 +788,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized boolean isContained(String subject, String container) throws PMException {
+    public boolean isContained(String subject, String container) throws PMException {
         if (!policy.graph().nodeExists(subject)) {
             throw new NodeDoesNotExistException(subject);
         } else if (!policy.graph().nodeExists(container)){
@@ -810,7 +810,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized List<Prohibition> getInheritedProhibitionsFor(String subject) throws PMException {
+    public List<Prohibition> getInheritedProhibitionsFor(String subject) throws PMException {
         List<Prohibition> pros = new ArrayList<>();
 
         new DepthFirstGraphWalker(policy.graph())
@@ -841,7 +841,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized List<Obligation> getObligationsWithAuthor(UserContext userCtx) throws PMException {
+    public List<Obligation> getObligationsWithAuthor(UserContext userCtx) throws PMException {
         List<Obligation> obls = new ArrayList<>();
         for (Obligation obligation : policy.obligations().getAll()) {
             if (obligation.getAuthor().equals(userCtx)) {
@@ -853,7 +853,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized List<Obligation> getObligationsWithAttributeInEvent(String attribute) throws PMException {
+    public List<Obligation> getObligationsWithAttributeInEvent(String attribute) throws PMException {
         List<Obligation> obls = new ArrayList<>();
         for (Obligation obligation : policy.obligations().getAll()) {
             List<Rule> rules = obligation.getRules();
@@ -881,7 +881,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized List<Obligation> getObligationsWithAttributeInResponse(String attribute) throws PMException {
+    public List<Obligation> getObligationsWithAttributeInResponse(String attribute) throws PMException {
         List<Obligation> obls = new ArrayList<>();
         for (Obligation obligation : policy.obligations().getAll()) {
             List<Rule> rules = obligation.getRules();
@@ -901,7 +901,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
     }
 
     @Override
-    public synchronized List<Obligation> getObligationsWithEvent(String event) throws PMException {
+    public List<Obligation> getObligationsWithEvent(String event) throws PMException {
         List<Obligation> obls = new ArrayList<>();
         for (Obligation obligation : policy.obligations().getAll()) {
             List<Rule> rules = obligation.getRules();
@@ -915,7 +915,7 @@ public class MemoryPolicyReviewer extends PolicyReviewer {
         return obls;
     }
     @Override
-    public synchronized List<Response> getMatchingEventResponses(EventContext evt) throws PMException {
+    public List<Response> getMatchingEventResponses(EventContext evt) throws PMException {
         List<Response> responses = new ArrayList<>();
         for (Obligation obligation : policy.obligations().getAll()) {
             for (Rule rule : obligation.getRules()) {


### PR DESCRIPTION
There is currently no coherent approach to concurrency with the PAP and PDP objects. The memory implementation is designed to be single threaded while the Mysql implementation can be multi threaded. This PR removes the synchronized keyword from some memory methods, which will be reintroduced later when there is a clear approach.

- also updates java version in maven to 17