### PR TITLE
fix neo4j embedded setResourceOps error

### DIFF
--- a/src/main/java/gov/nist/csd/pm/core/pap/modification/GraphModifier.java
+++ b/src/main/java/gov/nist/csd/pm/core/pap/modification/GraphModifier.java
@@ -426,6 +426,8 @@ public class GraphModifier extends Modifier implements GraphModification {
             throws PMException {
         long id = idGenerator.generateId(name, type);
 
+
+
         if (name.equals(AdminPolicyNode.PM_ADMIN_POLICY_CLASSES.nodeName())) {
             return AdminPolicyNode.PM_ADMIN_POLICY_CLASSES.nodeId();
         } else if (policyStore.graph().nodeExists(name)) {

--- a/src/main/java/gov/nist/csd/pm/core/pdp/bootstrap/JSONBootstrapper.java
+++ b/src/main/java/gov/nist/csd/pm/core/pdp/bootstrap/JSONBootstrapper.java
@@ -11,13 +11,6 @@ public class JSONBootstrapper extends PolicyBootstrapper{
 
     private String json;
 
-    public JSONBootstrapper(List<Operation<?, ?>> operations,
-                            List<Routine<?, ?>> routines,
-                            String json) {
-        super(operations, routines);
-        this.json = json;
-    }
-
     @Override
     public void bootstrap(PAP pap) throws PMException {
         pap.deserialize(json, new JSONDeserializer());

--- a/src/main/java/gov/nist/csd/pm/core/pdp/bootstrap/PMLBootstrapper.java
+++ b/src/main/java/gov/nist/csd/pm/core/pdp/bootstrap/PMLBootstrapper.java
@@ -10,11 +10,14 @@ import java.util.List;
 
 public class PMLBootstrapper extends PolicyBootstrapper {
 
+    private List<Operation<?, ?>> operations;
+    private List<Routine<?, ?>> routines;
     private final String bootstrapUser;
     private final String pml;
 
     public PMLBootstrapper(List<Operation<?, ?>> operations, List<Routine<?, ?>> routines, String bootstrapUser, String pml) {
-        super(operations, routines);
+        this.operations = operations;
+        this.routines = routines;
         this.bootstrapUser = bootstrapUser;
         this.pml = pml;
     }

--- a/src/main/java/gov/nist/csd/pm/core/pdp/bootstrap/PolicyBootstrapper.java
+++ b/src/main/java/gov/nist/csd/pm/core/pdp/bootstrap/PolicyBootstrapper.java
@@ -2,24 +2,11 @@ package gov.nist.csd.pm.core.pdp.bootstrap;
 
 import gov.nist.csd.pm.core.common.exception.PMException;
 import gov.nist.csd.pm.core.pap.PAP;
-import gov.nist.csd.pm.core.pap.function.op.Operation;
-import gov.nist.csd.pm.core.pap.function.routine.Routine;
-import java.util.ArrayList;
-import java.util.List;
 
 public abstract class PolicyBootstrapper {
 
-    protected List<Operation<?, ?>> operations;
-    protected List<Routine<?, ?>> routines;
-
     public PolicyBootstrapper() {
-        operations = new ArrayList<>();
-        routines = new ArrayList<>();
-    }
 
-    public PolicyBootstrapper(List<Operation<?, ?>> operations, List<Routine<?, ?>> routines) {
-        this.operations = operations;
-        this.routines = routines;
     }
 
     public abstract void bootstrap(PAP pap) throws PMException;

--- a/src/test/java/gov/nist/csd/pm/core/pap/query/OperationsQuerierTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/query/OperationsQuerierTest.java
@@ -66,6 +66,9 @@ public abstract class OperationsQuerierTest extends PAPTestInitializer {
             AccessRightSet arset = new AccessRightSet("read", "write");
             pap.modify().operations().setResourceOperations(arset);
             assertEquals(arset, pap.query().operations().getResourceOperations());
+            arset = new AccessRightSet("read", "write", "execute");
+            pap.modify().operations().setResourceOperations(arset);
+            assertEquals(arset, pap.query().operations().getResourceOperations());
         }
     }
 

--- a/src/test/java/gov/nist/csd/pm/core/pap/serialization/json/JSONSerializerTest.java
+++ b/src/test/java/gov/nist/csd/pm/core/pap/serialization/json/JSONSerializerTest.java
@@ -1,7 +1,11 @@
 package gov.nist.csd.pm.core.pap.serialization.json;
 
 import gov.nist.csd.pm.core.common.exception.PMException;
+import gov.nist.csd.pm.core.common.graph.node.NodeType;
 import gov.nist.csd.pm.core.impl.memory.pap.MemoryPAP;
+import gov.nist.csd.pm.core.impl.memory.pap.store.MemoryGraphStore;
+import gov.nist.csd.pm.core.impl.memory.pap.store.MemoryPolicy;
+import gov.nist.csd.pm.core.impl.memory.pap.store.MemoryPolicyStore;
 import gov.nist.csd.pm.core.util.PolicyEquals;
 import gov.nist.csd.pm.core.util.SamplePolicy;
 import java.io.IOException;
@@ -20,6 +24,13 @@ class JSONSerializerTest {
         pap2.serialize(new JSONSerializer());
 
         PolicyEquals.assertPolicyEquals(pap.query(), pap2.query());
+    }
+
+    @Test
+    void testWithAdminPolicyDoesNotError() throws PMException {
+
+        MemoryPolicyStore memoryPolicyStore = new MemoryPolicyStore();
+        memoryPolicyStore.graph().createNode(-1, "PM_ADMIN", NodeType.PC);
     }
 
 }


### PR DESCRIPTION
fixes issue where neo4j setResourceOps method was creating more nodes instead of updating existing node
small refactor to bootstrapper since using functions depends on the impl of bootstrapper not all bootstrappers need them.